### PR TITLE
walkingkooka a1575ba28ca4b41ad4cc168bb7956ca4fd7387a8 20190711

### DIFF
--- a/src/main/java/walkingkooka/tree/text/TextNode.java
+++ b/src/main/java/walkingkooka/tree/text/TextNode.java
@@ -318,6 +318,7 @@ public abstract class TextNode implements Node<TextNode, TextNodeName, TextStyle
     public final void buildToString(final ToStringBuilder b) {
         b.defaults();
         b.enable(ToStringBuilderOption.ESCAPE);
+        b.disable(ToStringBuilderOption.SKIP_IF_DEFAULT_VALUE);
         b.labelSeparator(": ");
         b.valueSeparator(", ");
         b.separator("");


### PR DESCRIPTION
https://github.com/mP1/walkingkooka/pull/1909

- added ToStringBuilderOption.SKIP_IF_DEFAULT_VALUE so empty children keeps surrounding brackets.