### PR TITLE
walkingkooka 2f83b92f7b9cff43f6b5359dd7fbfc6202ade410 20190809

### DIFF
--- a/src/test/java/walkingkooka/tree/text/BorderSpacingTest.java
+++ b/src/test/java/walkingkooka/tree/text/BorderSpacingTest.java
@@ -55,7 +55,7 @@ public final class BorderSpacingTest extends LengthTextStylePropertyValueTestCas
     // ParseStringTesting...............................................................................................
 
     @Override
-    public BorderSpacing parse(final String text) {
+    public BorderSpacing parseString(final String text) {
         return BorderSpacing.parse(text);
     }
 

--- a/src/test/java/walkingkooka/tree/text/LengthTest.java
+++ b/src/test/java/walkingkooka/tree/text/LengthTest.java
@@ -31,27 +31,27 @@ public final class LengthTest implements ClassTesting2<Length<?>>,
 
     @Test
     public void testParseIncorrectUnitFails() {
-        this.parseFails("12EM", IllegalArgumentException.class);
+        this.parseStringFails("12EM", IllegalArgumentException.class);
     }
 
     @Test
     public void testParseNone() {
-        this.parseAndCheck("none", Length.none());
+        this.parseStringAndCheck("none", Length.none());
     }
 
     @Test
     public void testParseNormal() {
-        this.parseAndCheck("normal", Length.normal());
+        this.parseStringAndCheck("normal", Length.normal());
     }
 
     @Test
     public void testParseNumber() {
-        this.parseAndCheck("123", Length.number(123L));
+        this.parseStringAndCheck("123", Length.number(123L));
     }
 
     @Test
     public void testParsePixels() {
-        this.parseAndCheck("12.5px", Length.pixel(12.5));
+        this.parseStringAndCheck("12.5px", Length.pixel(12.5));
     }
 
     // ClassTesting.....................................................................................................
@@ -69,17 +69,17 @@ public final class LengthTest implements ClassTesting2<Length<?>>,
     // ParseStringTesting...............................................................................................
 
     @Override
-    public Length<?> parse(final String text) {
+    public Length<?> parseString(final String text) {
         return Length.parse(text);
     }
 
     @Override
-    public Class<? extends RuntimeException> parseFailedExpected(final Class<? extends RuntimeException> expected) {
+    public Class<? extends RuntimeException> parseStringFailedExpected(final Class<? extends RuntimeException> expected) {
         return expected;
     }
 
     @Override
-    public RuntimeException parseFailedExpected(final RuntimeException expected) {
+    public RuntimeException parseStringFailedExpected(final RuntimeException expected) {
         return expected;
     }
 

--- a/src/test/java/walkingkooka/tree/text/LengthTestCase.java
+++ b/src/test/java/walkingkooka/tree/text/LengthTestCase.java
@@ -101,12 +101,12 @@ public abstract class LengthTestCase<L extends Length, V> implements ClassTestin
     // ParseStringTesting...............................................................................................
 
     @Override
-    public final Class<? extends RuntimeException> parseFailedExpected(final Class<? extends RuntimeException> expected) {
+    public final Class<? extends RuntimeException> parseStringFailedExpected(final Class<? extends RuntimeException> expected) {
         return expected;
     }
 
     @Override
-    public final RuntimeException parseFailedExpected(final RuntimeException expected) {
+    public final RuntimeException parseStringFailedExpected(final RuntimeException expected) {
         return expected;
     }
 

--- a/src/test/java/walkingkooka/tree/text/LengthTextStylePropertyValueTestCase.java
+++ b/src/test/java/walkingkooka/tree/text/LengthTextStylePropertyValueTestCase.java
@@ -55,7 +55,7 @@ public abstract class LengthTextStylePropertyValueTestCase<L extends LengthTextS
     @Test
     public final void testParse() {
         final L propertyValue = this.createPropertyValue();
-        this.parseAndCheck(propertyValue.toString(), propertyValue);
+        this.parseStringAndCheck(propertyValue.toString(), propertyValue);
     }
 
     @Test
@@ -118,12 +118,12 @@ public abstract class LengthTextStylePropertyValueTestCase<L extends LengthTextS
     // ParseStringTesting...............................................................................................
 
     @Override
-    public final Class<? extends RuntimeException> parseFailedExpected(final Class<? extends RuntimeException> expected) {
+    public final Class<? extends RuntimeException> parseStringFailedExpected(final Class<? extends RuntimeException> expected) {
         return expected;
     }
 
     @Override
-    public final RuntimeException parseFailedExpected(final RuntimeException expected) {
+    public final RuntimeException parseStringFailedExpected(final RuntimeException expected) {
         return expected;
     }
 

--- a/src/test/java/walkingkooka/tree/text/LetterSpacingTest.java
+++ b/src/test/java/walkingkooka/tree/text/LetterSpacingTest.java
@@ -55,7 +55,7 @@ public final class LetterSpacingTest extends LengthTextStylePropertyValueTestCas
     // ParseStringTesting...............................................................................................
 
     @Override
-    public LetterSpacing parse(final String text) {
+    public LetterSpacing parseString(final String text) {
         return LetterSpacing.parse(text);
     }
 

--- a/src/test/java/walkingkooka/tree/text/NoneLengthTest.java
+++ b/src/test/java/walkingkooka/tree/text/NoneLengthTest.java
@@ -31,12 +31,12 @@ public final class NoneLengthTest extends LengthTestCase<NoneLength, Void> {
 
     @Test
     public void testParseInvalidTextFails() {
-        this.parseFails("12px", IllegalArgumentException.class);
+        this.parseStringFails("12px", IllegalArgumentException.class);
     }
 
     @Test
     public void testParse() {
-        this.parseAndCheck("none", NoneLength.INSTANCE);
+        this.parseStringAndCheck("none", NoneLength.INSTANCE);
     }
 
     @Test
@@ -104,7 +104,7 @@ public final class NoneLengthTest extends LengthTestCase<NoneLength, Void> {
     // ParseStringTesting...............................................................................................
 
     @Override
-    public NoneLength parse(final String text) {
+    public NoneLength parseString(final String text) {
         return Length.parseNone(text);
     }
     // HasJsonNodeTesting...............................................................................................

--- a/src/test/java/walkingkooka/tree/text/NormalLengthTest.java
+++ b/src/test/java/walkingkooka/tree/text/NormalLengthTest.java
@@ -31,12 +31,12 @@ public final class NormalLengthTest extends LengthTestCase<NormalLength, Void> {
 
     @Test
     public void testParseInvalidTextFails() {
-        this.parseFails("12px", IllegalArgumentException.class);
+        this.parseStringFails("12px", IllegalArgumentException.class);
     }
 
     @Test
     public void testParse() {
-        this.parseAndCheck("normal", NormalLength.INSTANCE);
+        this.parseStringAndCheck("normal", NormalLength.INSTANCE);
     }
 
     @Test
@@ -104,7 +104,7 @@ public final class NormalLengthTest extends LengthTestCase<NormalLength, Void> {
     // ParseStringTesting...............................................................................................
 
     @Override
-    public NormalLength parse(final String text) {
+    public NormalLength parseString(final String text) {
         return NormalLength.parseNormal(text);
     }
     // HasJsonNodeTesting...............................................................................................

--- a/src/test/java/walkingkooka/tree/text/NumberLengthTest.java
+++ b/src/test/java/walkingkooka/tree/text/NumberLengthTest.java
@@ -31,22 +31,22 @@ public final class NumberLengthTest extends LengthTestCase<NumberLength, Long> {
 
     @Test
     public void testParseInvalidNumberFails() {
-        this.parseFails("A", IllegalArgumentException.class);
+        this.parseStringFails("A", IllegalArgumentException.class);
     }
 
     @Test
     public void testParseIncorrectUnitFails() {
-        this.parseFails("12EM", IllegalArgumentException.class);
+        this.parseStringFails("12EM", IllegalArgumentException.class);
     }
 
     @Test
     public void testParseIncorrectUnitCaseFails() {
-        this.parseFails("12PX", IllegalArgumentException.class);
+        this.parseStringFails("12PX", IllegalArgumentException.class);
     }
 
     @Test
     public void testParse() {
-        this.parseAndCheck("12", NumberLength.with(12L));
+        this.parseStringAndCheck("12", NumberLength.with(12L));
     }
 
     @Test
@@ -132,7 +132,7 @@ public final class NumberLengthTest extends LengthTestCase<NumberLength, Long> {
     // ParseStringTesting...............................................................................................
 
     @Override
-    public NumberLength parse(final String text) {
+    public NumberLength parseString(final String text) {
         return NumberLength.parseNumber(text);
     }
     // HasJsonNodeTesting...............................................................................................

--- a/src/test/java/walkingkooka/tree/text/PixelLengthTest.java
+++ b/src/test/java/walkingkooka/tree/text/PixelLengthTest.java
@@ -31,37 +31,37 @@ public final class PixelLengthTest extends LengthTestCase<PixelLength, Double> {
 
     @Test
     public void testParseMissingUnitFails() {
-        this.parseFails("12", IllegalArgumentException.class);
+        this.parseStringFails("12", IllegalArgumentException.class);
     }
 
     @Test
     public void testParseInvalidValueFails() {
-        this.parseFails("!px", IllegalArgumentException.class);
+        this.parseStringFails("!px", IllegalArgumentException.class);
     }
 
     @Test
     public void testParseIncorrectUnitFails() {
-        this.parseFails("12EM", IllegalArgumentException.class);
+        this.parseStringFails("12EM", IllegalArgumentException.class);
     }
 
     @Test
     public void testParseIncorrectUnitCaseFails() {
-        this.parseFails("12PX", IllegalArgumentException.class);
+        this.parseStringFails("12PX", IllegalArgumentException.class);
     }
 
     @Test
     public void testParse() {
-        this.parseAndCheck("12px", PixelLength.with(12));
+        this.parseStringAndCheck("12px", PixelLength.with(12));
     }
 
     @Test
     public void testParse2() {
-        this.parseAndCheck("12.5px", PixelLength.with(12.5));
+        this.parseStringAndCheck("12.5px", PixelLength.with(12.5));
     }
 
     @Test
     public void testParse3() {
-        this.parseAndCheck("345.75px", PixelLength.with(345.75));
+        this.parseStringAndCheck("345.75px", PixelLength.with(345.75));
     }
 
     @Test
@@ -152,7 +152,7 @@ public final class PixelLengthTest extends LengthTestCase<PixelLength, Double> {
     // ParseStringTesting...............................................................................................
 
     @Override
-    public PixelLength parse(String text) {
+    public PixelLength parseString(final String text) {
         return PixelLength.parsePixels(text);
     }
     // HasJsonNodeTesting...............................................................................................

--- a/src/test/java/walkingkooka/tree/text/WordSpacingTest.java
+++ b/src/test/java/walkingkooka/tree/text/WordSpacingTest.java
@@ -55,7 +55,7 @@ public final class WordSpacingTest extends LengthTextStylePropertyValueTestCase<
     // ParseStringTesting...............................................................................................
 
     @Override
-    public WordSpacing parse(final String text) {
+    public WordSpacing parseString(final String text) {
         return WordSpacing.parse(text);
     }
 


### PR DESCRIPTION
- https://github.com/mP1/walkingkooka/pull/2087
- ParseStringTesting method names changes avoid ParserTesting clashes