### PR TITLE
walkingkooka-tree/pull/204 20201102

### DIFF
--- a/src/it/junit-test/src/test/java/test/JunitTest.java
+++ b/src/it/junit-test/src/test/java/test/JunitTest.java
@@ -48,7 +48,7 @@ public class JunitTest {
                 );
 
         final StringBuilder html = new StringBuilder();
-        final LineEnding eol = LineEnding.NL;
+        final LineEnding eol = LineEnding.SYSTEM;
         final IndentingPrinter printer = Printers.stringBuilder(html, eol)
                 .indenting(Indentation.with("  "));
 

--- a/src/test/java/walkingkooka/tree/text/TextNodeTest.java
+++ b/src/test/java/walkingkooka/tree/text/TextNodeTest.java
@@ -20,13 +20,8 @@ package walkingkooka.tree.text;
 import org.junit.jupiter.api.Test;
 import walkingkooka.ToStringTesting;
 import walkingkooka.collect.list.Lists;
-import walkingkooka.convert.ConverterContexts;
-import walkingkooka.convert.Converters;
 import walkingkooka.reflect.JavaVisibility;
-import walkingkooka.tree.expression.ExpressionNumberContexts;
-import walkingkooka.tree.expression.ExpressionNumberConverterContexts;
-import walkingkooka.tree.expression.ExpressionNumberKind;
-import walkingkooka.tree.select.NodeSelectorContexts;
+import walkingkooka.tree.expression.ExpressionEvaluationContexts;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -49,7 +44,7 @@ public final class TextNodeTest extends TextNodeTestCase<TextNode> implements To
         assertEquals(2, TextNode.absoluteNodeSelector()
                 .descendant()
                 .named(Text.NAME)
-                .stream(node, NodeSelectorContexts.basicFunctions(), Converters.fake(), ExpressionNumberConverterContexts.fake(), TextNode.class)
+                .stream(node, (c) -> ExpressionEvaluationContexts.fake(), TextNode.class)
                 .count());
     }
 


### PR DESCRIPTION
- https://github.com/mP1/walkingkooka-tree/pull/204
- ExpressionFunction ExpressionFunctionContext type parameter

- NodeSelectorContext removed convert, function methods.
- BasicNodeSelectorContext removed Converter, ConverterContext, Function functions replaced with Function<NodeSelectorContext, ExpressionEvaluationContext>
- Introduced NodeSelectorExpressionFunctionContext
- Added NodeExpressionFunction

- https://github.com/mP1/walkingkooka-tree/issues/201
- NodeExpressionFunction returns current Node by querying NodeExpressionFunctionContext.node()

- https://github.com/mP1/walkingkooka-tree/issues/200
- NodeSelectorExpressionFunctionContext extends ExpressionFunctionContext

- https://github.com/mP1/walkingkooka-tree/issues/193
- NodeSelectorContext need a better way to share current Node with expressions