### PR TITLE
TextStylePropertyName Length JsonNodeContext.register fix

### DIFF
--- a/src/main/java/walkingkooka/tree/text/TextStylePropertyName.java
+++ b/src/main/java/walkingkooka/tree/text/TextStylePropertyName.java
@@ -741,6 +741,7 @@ public final class TextStylePropertyName<T> extends TextNodeNameName<TextStylePr
         FontFamily.with("Times New Roman");
         FontSize.with(1);
         FontWeight.NORMAL.value();
+        Length.none();
         Opacity.OPAQUE.value();
         TextOverflow.CLIP.value();
 


### PR DESCRIPTION
- Fixes marshalling/unmarshalling failures due to Length not being registered.