### PR TITLE
TextStyle patch null value fix

### DIFF
--- a/src/main/java/walkingkooka/tree/text/TextStyle.java
+++ b/src/main/java/walkingkooka/tree/text/TextStyle.java
@@ -251,9 +251,11 @@ public abstract class TextStyle implements Value<Map<TextStylePropertyName<?>, O
             final TextStylePropertyName<?> name = TextStylePropertyName.unmarshall(nameAndValue);
             result = result.setOrRemove(
                     name,
-                    Cast.to(
-                            name.handler.unmarshall(nameAndValue, name, context)
-                    )
+                    nameAndValue.isNull() ?
+                            null :
+                            Cast.to(
+                                    name.handler.unmarshall(nameAndValue, name, context)
+                            )
             );
         }
 

--- a/src/test/java/walkingkooka/tree/text/TextStyleTest.java
+++ b/src/test/java/walkingkooka/tree/text/TextStyleTest.java
@@ -266,6 +266,28 @@ public final class TextStyleTest implements ClassTesting2<TextStyle>,
     }
 
     @Test
+    public void testPatchRemoveProperty() {
+        this.patchAndCheck(
+                TextStyle.EMPTY
+                        .set(TextStylePropertyName.BACKGROUND_COLOR, Color.BLACK),
+                JsonNode.object()
+                        .set(JsonPropertyName.with(TextStylePropertyName.BACKGROUND_COLOR.value()), JsonNode.nullNode()),
+                TextStyle.EMPTY
+        );
+    }
+
+    @Test
+    public void testPatchRemovePropertyEnum() {
+        this.patchAndCheck(
+                TextStyle.EMPTY
+                        .set(TextStylePropertyName.TEXT_ALIGN, TextAlign.RIGHT),
+                JsonNode.object()
+                        .set(JsonPropertyName.with(TextStylePropertyName.TEXT_ALIGN.value()), JsonNode.nullNode()),
+                TextStyle.EMPTY
+        );
+    }
+
+    @Test
     public void testPatchSetProperty() {
         this.patchAndCheck(
                 TextStyle.EMPTY,


### PR DESCRIPTION
- Previously a patch an enum property with null would fail because handler expected ONLY strings.