### PR TITLE
FontWeight.BOLD & NORMAL marshall fix

### DIFF
--- a/src/main/java/walkingkooka/tree/text/TextStylePropertyValueHandlerFontWeight.java
+++ b/src/main/java/walkingkooka/tree/text/TextStylePropertyValueHandlerFontWeight.java
@@ -82,7 +82,7 @@ final class TextStylePropertyValueHandlerFontWeight extends TextStylePropertyVal
     @Override
     JsonNode marshall(final FontWeight value,
                       final JsonNodeMarshallContext context) {
-        return JsonNode.number(value.value());
+        return context.marshall(value);
     }
 
     // Object ..........................................................................................................

--- a/src/test/java/walkingkooka/tree/text/FontWeightTest.java
+++ b/src/test/java/walkingkooka/tree/text/FontWeightTest.java
@@ -130,7 +130,26 @@ public final class FontWeightTest extends TextStylePropertyValueTestCase2<FontWe
 
     @Test
     public void testMarshall() {
-        this.marshallAndCheck(this.createComparable(), JsonNode.number(VALUE));
+        this.marshallAndCheck(
+                this.createComparable(),
+                JsonNode.number(VALUE)
+        );
+    }
+
+    @Test
+    public void testMarshallBold() {
+        this.marshallAndCheck(
+                FontWeight.BOLD,
+                JsonNode.string(FontWeight.BOLD_TEXT)
+        );
+    }
+
+    @Test
+    public void testMarshallNormal() {
+        this.marshallAndCheck(
+                FontWeight.NORMAL,
+                JsonNode.string(FontWeight.NORMAL_TEXT)
+        );
     }
 
     @Test


### PR DESCRIPTION
- BOLD and NORMAL were always being marshalled into a JsonNumber with the numeric value.