### PR TITLE
Text.setAttribute not empty attributes fix

### DIFF
--- a/src/it/gwt-jar-test/src/test/java/test/TestGwtTest.java
+++ b/src/it/gwt-jar-test/src/test/java/test/TestGwtTest.java
@@ -37,7 +37,7 @@ public class TestGwtTest extends GWTTestCase {
                 .appendChild(TextNode.styleName(TextStyleName.with("head")).appendChild(TextNode.styleName(TextStyleName.with("TITLE")).appendChild(TextNode.text("title123"))))
                 .appendChild(TextNode.styleName(TextStyleName.with("BODY"))
                         .appendChild(TextNode.text("before"))
-                        .appendChild(TextNode.text("something gray").setAttributes(Maps.of(TextStylePropertyName.COLOR, Color.parse("#345"))).parentOrFail())
+                        .appendChild(TextNode.text("something gray").setAttributes(Maps.of(TextStylePropertyName.COLOR, Color.parse("#678"))))
                         .appendChild(TextNode.text("after"))
                 );
 
@@ -117,7 +117,7 @@ public class TestGwtTest extends GWTTestCase {
                 "  </head>\n" +
                 "  <BODY>\n" +
                 "    before\n" +
-                "    <SPAN style=\"color: #334455;\">\n" +
+                "    <SPAN style=\"color: #667788;\">\n" +
                 "      something gray\n" +
                 "    </SPAN>\n" +
                 "    after\n" +

--- a/src/it/junit-test/src/test/java/test/JunitTest.java
+++ b/src/it/junit-test/src/test/java/test/JunitTest.java
@@ -43,7 +43,7 @@ public class JunitTest {
                 .appendChild(TextNode.styleName(TextStyleName.with("head")).appendChild(TextNode.styleName(TextStyleName.with("TITLE")).appendChild(TextNode.text("title123"))))
                 .appendChild(TextNode.styleName(TextStyleName.with("BODY"))
                         .appendChild(TextNode.text("before"))
-                        .appendChild(TextNode.text("something gray").setAttributes(Maps.of(TextStylePropertyName.COLOR, Color.parse("#345"))).parentOrFail())
+                        .appendChild(TextNode.text("something gray").setAttributes(Maps.of(TextStylePropertyName.COLOR, Color.parse("#678"))))
                         .appendChild(TextNode.text("after"))
                 );
 
@@ -114,7 +114,8 @@ public class JunitTest {
             }
         }.accept(node);
 
-        Assert.assertEquals("<HTML>\n" +
+        Assert.assertEquals(
+                "<HTML>\n" +
                 "  <head>\n" +
                 "    <TITLE>\n" +
                 "      title123\n" +
@@ -122,11 +123,13 @@ public class JunitTest {
                 "  </head>\n" +
                 "  <BODY>\n" +
                 "    before\n" +
-                "    <SPAN style=\"color: #334455;\">\n" +
+                "    <SPAN style=\"color: #667788;\">\n" +
                 "      something gray\n" +
                 "    </SPAN>\n" +
                 "    after\n" +
                 "  </BODY>\n" +
-                "</HTML>\n", html.toString());
+                "</HTML>\n",
+                html.toString()
+        );
     }
 }

--- a/src/main/java/walkingkooka/tree/text/TextLeafNode.java
+++ b/src/main/java/walkingkooka/tree/text/TextLeafNode.java
@@ -105,9 +105,17 @@ abstract class TextLeafNode<V> extends TextNode implements Value<V> {
         return this;
     }
 
+    /**
+     * Creates a new {@link TextStyleNode} with this leaf as its only child with the given attributes.
+     */
     @Override
     final TextNode setAttributesNonEmptyTextStyleMap(final TextNodeMap textStyleMap) {
-        return this.setAttributesNonEmptyTextStyleMap0(textStyleMap);
+        return TextStyleNode.with(
+                Lists.of(
+                        this
+                ),
+                textStyleMap
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/tree/text/TextNode.java
+++ b/src/main/java/walkingkooka/tree/text/TextNode.java
@@ -188,15 +188,6 @@ public abstract class TextNode implements Node<TextNode, TextNodeName, TextStyle
     abstract TextNode setAttributesNonEmptyTextStyleMap(final TextNodeMap textStyleMap);
 
     /**
-     * Default for all sub classes except for {@link TextStyleNode}.
-     */
-    final TextNode setAttributesNonEmptyTextStyleMap0(final TextNodeMap textStyleMap) {
-        return TextStyleNode.with(Lists.of(this), textStyleMap)
-                .replaceChild(this.parent(), this.index)
-                .children().get(0);
-    }
-
-    /**
      * Getter that returns a {@link TextStyle} view over attributes.
      */
     public abstract TextStyle textStyle();

--- a/src/main/java/walkingkooka/tree/text/TextStyleNameNode.java
+++ b/src/main/java/walkingkooka/tree/text/TextStyleNameNode.java
@@ -20,6 +20,7 @@ package walkingkooka.tree.text;
 import walkingkooka.Cast;
 import walkingkooka.NeverError;
 import walkingkooka.ToStringBuilder;
+import walkingkooka.collect.list.Lists;
 import walkingkooka.collect.map.Maps;
 import walkingkooka.text.CharSequences;
 import walkingkooka.text.printer.IndentingPrinter;
@@ -118,8 +119,17 @@ public final class TextStyleNameNode extends TextParentNode {
         return this;
     }
 
-    @Override TextNode setAttributesNonEmptyTextStyleMap(final TextNodeMap textStyleMap) {
-        return this.setAttributesNonEmptyTextStyleMap0(textStyleMap);
+    /**
+     * Factory that creates a new {@link TextStyleNode} with the given attributes and this as the only child.
+     */
+    @Override
+    TextNode setAttributesNonEmptyTextStyleMap(final TextNodeMap textStyleMap) {
+        return TextStyleNode.with(
+                Lists.of(
+                        this
+                ),
+                textStyleMap
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/tree/text/TextStyleNode.java
+++ b/src/main/java/walkingkooka/tree/text/TextStyleNode.java
@@ -118,7 +118,8 @@ public final class TextStyleNode extends TextParentNode {
         return this.setAttributesTextStyleMap(TextNodeMap.EMPTY);
     }
 
-    @Override TextStyleNode setAttributesNonEmptyTextStyleMap(final TextNodeMap textStyleMap) {
+    @Override
+    TextStyleNode setAttributesNonEmptyTextStyleMap(final TextNodeMap textStyleMap) {
         return this.setAttributesTextStyleMap(textStyleMap);
     }
 

--- a/src/test/java/walkingkooka/tree/text/TextNodeTestCase2.java
+++ b/src/test/java/walkingkooka/tree/text/TextNodeTestCase2.java
@@ -63,9 +63,13 @@ public abstract class TextNodeTestCase2<N extends TextNode> extends TextNodeTest
         final TextNode after = before.setAttributes(attributes);
         assertNotSame(after, before);
 
-        final TextStyleNode parent = after.parentOrFail().cast();
-        this.childCountCheck(parent, before);
-        this.checkEquals(attributes, parent.attributes(), "attributes");
+        this.parentMissingCheck(after);
+        this.childCountCheck(after, before);
+        this.checkEquals(
+                attributes,
+                after.attributes(),
+                "attributes"
+        );
     }
 
     // textStyle........................................................................................................

--- a/src/test/java/walkingkooka/tree/text/TextStyleNodeTest.java
+++ b/src/test/java/walkingkooka/tree/text/TextStyleNodeTest.java
@@ -247,10 +247,16 @@ public final class TextStyleNodeTest extends TextParentNodeTestCase<TextStyleNod
 
     @Test
     public void testMarshallWithStyleNodeAndChildren() {
-        this.marshallAndCheck(TextNode.text("text123")
-                        .setAttributes(Maps.of(TextStylePropertyName.BACKGROUND_COLOR, Color.fromRgb(0x123456)))
-                        .parentOrFail(),
-                "{\"styles\": {\"background-color\": \"#123456\"}, \"children\": [{\"type\": \"text\", \"value\": \"text123\"}]}");
+        this.marshallAndCheck(
+                TextNode.text("text123")
+                        .setAttributes(
+                                Maps.of(
+                                        TextStylePropertyName.BACKGROUND_COLOR,
+                                        Color.fromRgb(0x123456)
+                                )
+                        ),
+                "{\"styles\": {\"background-color\": \"#123456\"}, \"children\": [{\"type\": \"text\", \"value\": \"text123\"}]}"
+        );
     }
 
     @Test
@@ -484,10 +490,15 @@ public final class TextStyleNodeTest extends TextParentNodeTestCase<TextStyleNod
 
     @Test
     public void testToStringWithChildrenAndAttributes() {
-        this.toStringAndCheck(text1()
-                        .setAttributes(Maps.of(TextStylePropertyName.with("style-1"), "value-1"))
-                        .parentOrFail(),
-                "{style-1: \"value-1\"}[\"text-1a\"]");
+        this.toStringAndCheck(
+                text1().setAttributes(
+                        Maps.of(
+                                TextStylePropertyName.with("style-1"),
+                                "value-1"
+                        )
+                ),
+                "{style-1: \"value-1\"}[\"text-1a\"]"
+        );
     }
 
     @Test

--- a/src/test/java/walkingkooka/tree/text/TextStyleNonEmptyTest.java
+++ b/src/test/java/walkingkooka/tree/text/TextStyleNonEmptyTest.java
@@ -145,9 +145,15 @@ public final class TextStyleNonEmptyTest extends TextStyleTestCase<TextStyleNonE
         final TextStyleNameNode styleName = this.styleName("child-style123");
         final TextStyle textStyle = this.createTextStyle();
 
-        this.replaceAndCheck(textStyle,
+        this.replaceAndCheck(
+                textStyle,
                 this.makeStyleNameParent(styleName),
-                this.makeStyleNameParent(styleName.setAttributes(textStyle.value()).parentOrFail()).children().get(0));
+                this.makeStyleNameParent(
+                        styleName.setAttributes(
+                                textStyle.value()
+                        )
+                )
+        );
     }
 
     @Test
@@ -173,17 +179,25 @@ public final class TextStyleNonEmptyTest extends TextStyleTestCase<TextStyleNonE
     private void replaceAndCheck3(final TextNode textNode) {
         final TextStyle textStyle = this.createTextStyle();
 
-        this.replaceAndCheck(textStyle,
+        this.replaceAndCheck(
+                textStyle,
                 this.makeStyleNameParent(textNode),
-                this.makeStyleNameParent(TextStyleNode.with(Lists.of(textNode), textStyle.textStyleMap())).children().get(0));
+                this.makeStyleNameParent(
+                        TextStyleNode.with(
+                                Lists.of(textNode),
+                                textStyle.textStyleMap())
+                )
+        );
     }
 
     private void replaceAndCheck2(final TextNode textNode) {
         final TextStyle textStyle = this.createTextStyle();
 
-        this.replaceAndCheck(textStyle,
+        this.replaceAndCheck(
+                textStyle,
                 textNode,
-                textNode.setAttributes(textStyle.value()).parentOrFail().children().get(0));
+                textNode.setAttributes(textStyle.value())
+        );
     }
 
     // get..............................................................................................................

--- a/src/test/java/walkingkooka/tree/text/sample/Sample.java
+++ b/src/test/java/walkingkooka/tree/text/sample/Sample.java
@@ -38,7 +38,7 @@ public final class Sample {
                 .appendChild(TextNode.styleName(TextStyleName.with("head")).appendChild(TextNode.styleName(TextStyleName.with("TITLE")).appendChild(TextNode.text("title123"))))
                 .appendChild(TextNode.styleName(TextStyleName.with("BODY"))
                         .appendChild(TextNode.text("before"))
-                        .appendChild(TextNode.text("something gray").setAttributes(Maps.of(TextStylePropertyName.COLOR, Color.parse("#345"))).parentOrFail())
+                        .appendChild(TextNode.text("something gray").setAttributes(Maps.of(TextStylePropertyName.COLOR, Color.parse("#678"))))
                         .appendChild(TextNode.text("after"))
                 );
 
@@ -118,7 +118,7 @@ public final class Sample {
         //   </head>
         //   <BODY>
         //     before
-        //     <SPAN style="color: #334455;">
+        //     <SPAN style="color: #667788;">
         //       something gray
         //     </SPAN>
         //     after


### PR DESCRIPTION
- Previously Text.setAttributes always return the original Text.

- Closes https://github.com/mP1/walkingkooka-tree-text/issues/184
- Text.setAttribute should return a TextStyleNode with the Text as a child