### PR TITLE
Badly encoded spaces within Text.toHtml() fix

### DIFF
--- a/src/main/java/walkingkooka/tree/text/Text.java
+++ b/src/main/java/walkingkooka/tree/text/Text.java
@@ -81,11 +81,11 @@ public final class Text extends TextLeafNode<String> implements HasText {
     @Override
     public String toHtml() {
         return this.text()
-                .replace(" ", "&nbsp;")
                 .replace("\"", "&quot;")
                 .replace("&", "&amp;")
                 .replace("<", "&lt;")
-                .replace(">", "&gt;");
+                .replace(">", "&gt;")
+                .replace(" ", "&nbsp;");
     }
 
     // JsonNodeContext..................................................................................................

--- a/src/test/java/walkingkooka/tree/text/TextTest.java
+++ b/src/test/java/walkingkooka/tree/text/TextTest.java
@@ -120,12 +120,28 @@ public final class TextTest extends TextLeafNodeTestCase<Text, String> {
     }
 
     @Test
+    public void testToHtmlAmpersand() {
+        this.toHtmlAndCheck(
+                Text.with("&"),
+                "&amp;"
+        );
+    }
+
+    @Test
+    public void testToHtmlSpace() {
+        this.toHtmlAndCheck(
+                Text.with(" "),
+                "&nbsp;"
+        );
+    }
+
+    @Test
     public void testToHtmlEscaped() {
         final String text = "abc 123<>&\"'";
 
         this.toHtmlAndCheck(
                 Text.with(text),
-                "abc&amp;nbsp;123&lt;&gt;&amp;&amp;quot;'"
+                "abc&nbsp;123&lt;&gt;&amp;&amp;quot;'"
         );
     }
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-tree-text/issues/188
- Space badly html encoded should be "&nbsp;" but is "&amp;nbsp;"