### PR TITLE
TextStylePropertyName.ALL

### DIFF
--- a/src/main/java/walkingkooka/tree/text/TextStyle.java
+++ b/src/main/java/walkingkooka/tree/text/TextStyle.java
@@ -204,11 +204,14 @@ public abstract class TextStyle implements Value<Map<TextStylePropertyName<?>, O
 
     /**
      * Removes a possibly existing property returning a {@link TextStyle} without.
+     * {@link TextStylePropertyName#ALL} is a special case and always returns a {@link #EMPTY}.
      */
     public final TextStyle remove(final TextStylePropertyName<?> propertyName) {
         checkPropertyName(propertyName);
 
-        return this.remove0(propertyName);
+        return propertyName == TextStylePropertyName.ALL ?
+                TextStyle.EMPTY :
+                this.remove0(propertyName);
     }
 
     abstract TextStyle remove0(final TextStylePropertyName<?> propertyName);

--- a/src/main/java/walkingkooka/tree/text/TextStylePropertyName.java
+++ b/src/main/java/walkingkooka/tree/text/TextStylePropertyName.java
@@ -176,6 +176,15 @@ public final class TextStylePropertyName<T> extends TextNodeNameName<TextStylePr
     }
 
     /**
+     * A {@link TextStylePropertyName} that matches all.
+     */
+    public final static TextStylePropertyName<Void> ALL = registerConstant(
+            "*",
+            TextStylePropertyValueHandlerVoid.INSTANCE,
+            null
+    );
+
+    /**
      * Background rgb
      */
     public final static TextStylePropertyName<Color> BACKGROUND_COLOR = registerColor("background-color",

--- a/src/main/java/walkingkooka/tree/text/TextStylePropertyValueHandlerVoid.java
+++ b/src/main/java/walkingkooka/tree/text/TextStylePropertyValueHandlerVoid.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.text;
+
+import walkingkooka.text.CharSequences;
+import walkingkooka.tree.json.JsonNode;
+import walkingkooka.tree.json.marshall.JsonNodeMarshallContext;
+import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContext;
+
+import java.util.Optional;
+
+/**
+ * A {@link TextStylePropertyValueHandler} for {@link Void} parameter values.
+ */
+final class TextStylePropertyValueHandlerVoid extends TextStylePropertyValueHandler<Void> {
+
+    /**
+     * Singleton
+     */
+    final static TextStylePropertyValueHandlerVoid INSTANCE = new TextStylePropertyValueHandlerVoid();
+
+    /**
+     * Private ctor
+     */
+    private TextStylePropertyValueHandlerVoid() {
+        super();
+    }
+
+    @Override
+    Optional<Class<Enum<?>>> enumType() {
+        return Optional.empty();
+    }
+
+    @Override
+    void check0(final Object value,
+                final TextStylePropertyName<?> name) {
+        throw new TextStylePropertyValueException("Values not allowed");
+    }
+
+    @Override
+    String expectedTypeName(final Class<?> type) {
+        return Void.class.getSimpleName();
+    }
+
+    @Override
+    Void parseValue(final String value) {
+        if(value.length() > 0) {
+            throw new IllegalArgumentException("Only empty values allowed: " + CharSequences.quoteAndEscape(value));
+        }
+        return null;
+    }
+
+    // JsonNodeContext..................................................................................................
+
+    @Override
+    Void unmarshall(final JsonNode node,
+                    final TextStylePropertyName<?> name,
+                    final JsonNodeUnmarshallContext context) {
+        throw new UnsupportedOperationException("Unmarshalling " + name.inQuotes() + " with " + node + " is not supported");
+    }
+
+    @Override
+    JsonNode marshall(final Void value,
+                      final JsonNodeMarshallContext context) {
+        throw new UnsupportedOperationException("Marshalling value not supported");
+    }
+
+    // Object ..........................................................................................................
+
+    @Override
+    public String toString() {
+        return Void.class.getSimpleName();
+    }
+}

--- a/src/test/java/walkingkooka/tree/text/TextStylePropertyNameTest.java
+++ b/src/test/java/walkingkooka/tree/text/TextStylePropertyNameTest.java
@@ -63,14 +63,17 @@ public final class TextStylePropertyNameTest extends TextNodeNameNameTestCase<Te
 
     @Test
     public void testConstantValue() {
-        this.checkEquals(Lists.empty(),
-                Arrays.stream(TextStylePropertyName.class.getDeclaredFields())
+        this.checkEquals(
+                Lists.of("ALL=*"),
+                Arrays.stream(
+                        TextStylePropertyName.class.getDeclaredFields())
                         .filter(FieldAttributes.STATIC::is)
                         .filter(f -> f.getType() == TextStylePropertyName.class)
                         .map(TextStylePropertyNameTest::checkConstantAndValueCompatible)
                         .filter(v -> null != v)
                         .collect(Collectors.toList()),
-                "");
+                ""
+        );
     }
 
     private static String checkConstantAndValueCompatible(final Field field) {

--- a/src/test/java/walkingkooka/tree/text/TextStylePropertyValueHandlerEnumTest.java
+++ b/src/test/java/walkingkooka/tree/text/TextStylePropertyValueHandlerEnumTest.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 import walkingkooka.Cast;
 import walkingkooka.tree.json.JsonNode;
 
-public final class TextStylePropertyValueHandlerEnumTest extends TextStylePropertyValueHandlerTestCase2<TextStylePropertyValueHandlerEnum<TextWrapping>, TextWrapping> {
+public final class TextStylePropertyValueHandlerEnumTest extends TextStylePropertyValueHandlerTestCase3<TextStylePropertyValueHandlerEnum<TextWrapping>, TextWrapping> {
 
     @Test
     public void testUnmarshall() {

--- a/src/test/java/walkingkooka/tree/text/TextStylePropertyValueHandlerFontSizeTest.java
+++ b/src/test/java/walkingkooka/tree/text/TextStylePropertyValueHandlerFontSizeTest.java
@@ -20,7 +20,7 @@ package walkingkooka.tree.text;
 import org.junit.jupiter.api.Test;
 import walkingkooka.tree.json.JsonNode;
 
-public final class TextStylePropertyValueHandlerFontSizeTest extends TextStylePropertyValueHandlerTestCase2<TextStylePropertyValueHandlerFontSize, FontSize> {
+public final class TextStylePropertyValueHandlerFontSizeTest extends TextStylePropertyValueHandlerTestCase3<TextStylePropertyValueHandlerFontSize, FontSize> {
 
     @Test
     public void testUnmarshall() {

--- a/src/test/java/walkingkooka/tree/text/TextStylePropertyValueHandlerFontWeightTest.java
+++ b/src/test/java/walkingkooka/tree/text/TextStylePropertyValueHandlerFontWeightTest.java
@@ -20,7 +20,7 @@ package walkingkooka.tree.text;
 import org.junit.jupiter.api.Test;
 import walkingkooka.tree.json.JsonNode;
 
-public final class TextStylePropertyValueHandlerFontWeightTest extends TextStylePropertyValueHandlerTestCase2<TextStylePropertyValueHandlerFontWeight, FontWeight> {
+public final class TextStylePropertyValueHandlerFontWeightTest extends TextStylePropertyValueHandlerTestCase3<TextStylePropertyValueHandlerFontWeight, FontWeight> {
 
     @Test
     public void testUnmarshall() {

--- a/src/test/java/walkingkooka/tree/text/TextStylePropertyValueHandlerJsonNodeTest.java
+++ b/src/test/java/walkingkooka/tree/text/TextStylePropertyValueHandlerJsonNodeTest.java
@@ -22,7 +22,7 @@ import walkingkooka.Cast;
 import walkingkooka.color.Color;
 import walkingkooka.tree.json.JsonNode;
 
-public final class TextStylePropertyValueHandlerJsonNodeTest extends TextStylePropertyValueHandlerTestCase2<TextStylePropertyValueHandlerJsonNode<Color>, Color> {
+public final class TextStylePropertyValueHandlerJsonNodeTest extends TextStylePropertyValueHandlerTestCase3<TextStylePropertyValueHandlerJsonNode<Color>, Color> {
 
     @Test
     public void testUnmarshall() {

--- a/src/test/java/walkingkooka/tree/text/TextStylePropertyValueHandlerJsonNodeWithTypeTest.java
+++ b/src/test/java/walkingkooka/tree/text/TextStylePropertyValueHandlerJsonNodeWithTypeTest.java
@@ -23,7 +23,7 @@ import walkingkooka.color.Color;
 import walkingkooka.net.email.EmailAddress;
 import walkingkooka.tree.json.JsonNode;
 
-public final class TextStylePropertyValueHandlerJsonNodeWithTypeTest extends TextStylePropertyValueHandlerTestCase<TextStylePropertyValueHandlerJsonNodeWithType, Object> {
+public final class TextStylePropertyValueHandlerJsonNodeWithTypeTest extends TextStylePropertyValueHandlerTestCase2<TextStylePropertyValueHandlerJsonNodeWithType, Object> {
 
     @Test
     public void testUnmarshall() {

--- a/src/test/java/walkingkooka/tree/text/TextStylePropertyValueHandlerNoneLengthPixelLengthTest.java
+++ b/src/test/java/walkingkooka/tree/text/TextStylePropertyValueHandlerNoneLengthPixelLengthTest.java
@@ -22,7 +22,7 @@ import walkingkooka.tree.FakeNode;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public final class TextStylePropertyValueHandlerNoneLengthPixelLengthTest extends TextStylePropertyValueHandlerTestCase<TextStylePropertyValueHandlerNoneLengthPixelLength, Length<?>> {
+public final class TextStylePropertyValueHandlerNoneLengthPixelLengthTest extends TextStylePropertyValueHandlerTestCase2<TextStylePropertyValueHandlerNoneLengthPixelLength, Length<?>> {
 
     @Test
     public void testCheckNone() {

--- a/src/test/java/walkingkooka/tree/text/TextStylePropertyValueHandlerNormalLengthPixelLengthTest.java
+++ b/src/test/java/walkingkooka/tree/text/TextStylePropertyValueHandlerNormalLengthPixelLengthTest.java
@@ -22,7 +22,7 @@ import walkingkooka.tree.FakeNode;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public final class TextStylePropertyValueHandlerNormalLengthPixelLengthTest extends TextStylePropertyValueHandlerTestCase<TextStylePropertyValueHandlerNormalLengthPixelLength, Length<?>> {
+public final class TextStylePropertyValueHandlerNormalLengthPixelLengthTest extends TextStylePropertyValueHandlerTestCase2<TextStylePropertyValueHandlerNormalLengthPixelLength, Length<?>> {
 
     @Test
     public void testCheckNormal() {

--- a/src/test/java/walkingkooka/tree/text/TextStylePropertyValueHandlerStringTest.java
+++ b/src/test/java/walkingkooka/tree/text/TextStylePropertyValueHandlerStringTest.java
@@ -20,7 +20,7 @@ package walkingkooka.tree.text;
 import org.junit.jupiter.api.Test;
 import walkingkooka.tree.json.JsonNode;
 
-public final class TextStylePropertyValueHandlerStringTest extends TextStylePropertyValueHandlerTestCase2<TextStylePropertyValueHandlerString, String> {
+public final class TextStylePropertyValueHandlerStringTest extends TextStylePropertyValueHandlerTestCase3<TextStylePropertyValueHandlerString, String> {
 
     @Test
     public void testCheckEmptyStringFails() {

--- a/src/test/java/walkingkooka/tree/text/TextStylePropertyValueHandlerTestCase.java
+++ b/src/test/java/walkingkooka/tree/text/TextStylePropertyValueHandlerTestCase.java
@@ -22,7 +22,6 @@ import walkingkooka.ToStringTesting;
 import walkingkooka.reflect.ClassTesting;
 import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.reflect.TypeNameTesting;
-import walkingkooka.text.CharSequences;
 import walkingkooka.tree.expression.ExpressionNumberKind;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.marshall.JsonNodeMarshallContext;
@@ -47,23 +46,6 @@ public abstract class TextStylePropertyValueHandlerTestCase<P extends TextStyleP
         this.checkFails(
                 "Property " + this.propertyName().inQuotes() + " missing value"
         );
-    }
-
-    @Test
-    public final void testCheck() {
-        this.check(this.propertyValue());
-    }
-
-    @Test
-    public final void testRoundtripJson() {
-        final T value = this.propertyValue();
-        final P handler = this.handler();
-
-        final JsonNode json = handler.marshall(value, this.marshallContext());
-
-        this.checkEquals(value,
-                handler.unmarshall(json, this.propertyName(), this.unmarshallContext()),
-                () -> "value " + CharSequences.quoteIfChars(value) + " to json " + json);
     }
 
     final void check(final Object value) {
@@ -108,25 +90,11 @@ public abstract class TextStylePropertyValueHandlerTestCase<P extends TextStyleP
         );
     }
 
-    final void unmarshallAndCheck(final JsonNode node, final T value) {
-        this.checkEquals(value,
-                this.handler().unmarshall(node, this.propertyName(), this.unmarshallContext()),
-                () -> "from JsonNode " + node);
-    }
-
-    final void marshallAndCheck(final T value, final JsonNode node) {
-        this.checkEquals(node,
-                this.handler().marshall(value, this.marshallContext()),
-                () -> "marshall " + CharSequences.quoteIfChars(value));
-    }
-
     // helper...........................................................................................................
 
     abstract P handler();
 
     abstract TextStylePropertyName<T> propertyName();
-
-    abstract T propertyValue();
 
     abstract String propertyValueType();
 

--- a/src/test/java/walkingkooka/tree/text/TextStylePropertyValueHandlerTestCase2.java
+++ b/src/test/java/walkingkooka/tree/text/TextStylePropertyValueHandlerTestCase2.java
@@ -18,7 +18,8 @@
 package walkingkooka.tree.text;
 
 import org.junit.jupiter.api.Test;
-import walkingkooka.tree.FakeNode;
+import walkingkooka.text.CharSequences;
+import walkingkooka.tree.json.JsonNode;
 
 public abstract class TextStylePropertyValueHandlerTestCase2<P extends TextStylePropertyValueHandler<T>, T> extends TextStylePropertyValueHandlerTestCase<P, T> {
 
@@ -27,16 +28,37 @@ public abstract class TextStylePropertyValueHandlerTestCase2<P extends TextStyle
     }
 
     @Test
-    public final void testCheckWrongValueTypeFails() {
-        this.checkFails(this, "Property " + this.propertyName().inQuotes() + " value " + this + "(" + this.getClass().getSimpleName() + ") is not a " + this.propertyValueType());
+    public final void testCheck() {
+        this.check(this.propertyValue());
     }
 
     @Test
-    public final void testCheckWrongValueTypeFails2() {
-        final FakeNode<?, ?, ?, ?> fakeNode = new FakeNode<>();
-        this.checkFails(
-                fakeNode,
-                "Property " + this.propertyName().inQuotes() + " value " + fakeNode + "(" + FakeNode.class.getName() + ") is not a " + this.propertyValueType()
-        );
+    public final void testRoundtripJson() {
+        final T value = this.propertyValue();
+        final P handler = this.handler();
+
+        final JsonNode json = handler.marshall(value, this.marshallContext());
+
+        this.checkEquals(value,
+                handler.unmarshall(json, this.propertyName(), this.unmarshallContext()),
+                () -> "value " + CharSequences.quoteIfChars(value) + " to json " + json);
     }
+
+    final void unmarshallAndCheck(final JsonNode node, final T value) {
+        this.checkEquals(value,
+                this.handler().unmarshall(node, this.propertyName(), this.unmarshallContext()),
+                () -> "from JsonNode " + node);
+    }
+
+    final void marshallAndCheck(final T value, final JsonNode node) {
+        this.checkEquals(node,
+                this.handler().marshall(value, this.marshallContext()),
+                () -> "marshall " + CharSequences.quoteIfChars(value));
+    }
+
+    // helper...........................................................................................................
+
+    abstract T propertyValue();
+
+    abstract String propertyValueType();
 }

--- a/src/test/java/walkingkooka/tree/text/TextStylePropertyValueHandlerTestCase3.java
+++ b/src/test/java/walkingkooka/tree/text/TextStylePropertyValueHandlerTestCase3.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.text;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.tree.FakeNode;
+
+public abstract class TextStylePropertyValueHandlerTestCase3<P extends TextStylePropertyValueHandler<T>, T> extends TextStylePropertyValueHandlerTestCase2<P, T> {
+
+    TextStylePropertyValueHandlerTestCase3() {
+        super();
+    }
+
+    @Test
+    public final void testCheckWrongValueTypeFails() {
+        this.checkFails(this, "Property " + this.propertyName().inQuotes() + " value " + this + "(" + this.getClass().getSimpleName() + ") is not a " + this.propertyValueType());
+    }
+
+    @Test
+    public final void testCheckWrongValueTypeFails2() {
+        final FakeNode<?, ?, ?, ?> fakeNode = new FakeNode<>();
+        this.checkFails(
+                fakeNode,
+                "Property " + this.propertyName().inQuotes() + " value " + fakeNode + "(" + FakeNode.class.getName() + ") is not a " + this.propertyValueType()
+        );
+    }
+}

--- a/src/test/java/walkingkooka/tree/text/TextStylePropertyValueHandlerVoidTest.java
+++ b/src/test/java/walkingkooka/tree/text/TextStylePropertyValueHandlerVoidTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.text;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.tree.json.JsonNode;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public final class TextStylePropertyValueHandlerVoidTest extends TextStylePropertyValueHandlerTestCase<TextStylePropertyValueHandlerVoid, Void> {
+
+    @Test
+    public void testUnmarshallFails() {
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> this.handler()
+                        .unmarshall(
+                                JsonNode.nullNode(),
+                                this.propertyName(),
+                                this.unmarshallContext()
+                        )
+        );
+    }
+
+    @Test
+    public void testToString() {
+        this.toStringAndCheck(this.handler(), Void.class.getSimpleName());
+    }
+
+    @Override
+    TextStylePropertyValueHandlerVoid handler() {
+        return TextStylePropertyValueHandlerVoid.INSTANCE;
+    }
+
+    @Override
+    TextStylePropertyName<Void> propertyName() {
+        return TextStylePropertyName.ALL;
+    }
+
+    @Override
+    String propertyValueType() {
+        return Void.class.getSimpleName();
+    }
+
+    @Override
+    public String typeNameSuffix() {
+        return Void.class.getSimpleName();
+    }
+
+    @Override
+    public Class<TextStylePropertyValueHandlerVoid> type() {
+        return TextStylePropertyValueHandlerVoid.class;
+    }
+}

--- a/src/test/java/walkingkooka/tree/text/TextStyleTest.java
+++ b/src/test/java/walkingkooka/tree/text/TextStyleTest.java
@@ -171,7 +171,18 @@ public final class TextStyleTest implements ClassTesting2<TextStyle>,
 
     @Test
     public void testGetOrFail() {
-        assertThrows(TextStylePropertyValueException.class, () -> this.createObject().getOrFail(TextStylePropertyName.WIDTH));
+        assertThrows(
+                TextStylePropertyValueException.class,
+                () -> this.createObject().getOrFail(TextStylePropertyName.WIDTH)
+        );
+    }
+
+    @Test
+    public void testGetOrFailAll() {
+        assertThrows(
+                TextStylePropertyValueException.class,
+                () -> this.createObject().getOrFail(TextStylePropertyName.ALL)
+        );
     }
 
     // setOrRemove......................................................................................................
@@ -180,9 +191,23 @@ public final class TextStyleTest implements ClassTesting2<TextStyle>,
     public void testSetOrRemoveNonNullValue() {
         final TextStyle style = TextStyle.EMPTY
                 .set(TextStylePropertyName.BACKGROUND_COLOR, Color.BLACK);
-        this.checkEquals(
-                style.set(TextStylePropertyName.COLOR, Color.WHITE),
-                style.setOrRemove(TextStylePropertyName.COLOR, Color.WHITE)
+        this.setOrRemoveAndCheck(
+                style,
+                TextStylePropertyName.COLOR,
+                Color.WHITE,
+                style.set(TextStylePropertyName.COLOR, Color.WHITE)
+        );
+    }
+
+    @Test
+    public void testSetOrRemoveAllNullValue() {
+        final TextStyle style = TextStyle.EMPTY
+                .set(TextStylePropertyName.BACKGROUND_COLOR, Color.BLACK);
+        this.setOrRemoveAndCheck(
+                style,
+                TextStylePropertyName.BACKGROUND_COLOR,
+                null,
+                style.remove(TextStylePropertyName.BACKGROUND_COLOR)
         );
     }
 
@@ -190,9 +215,22 @@ public final class TextStyleTest implements ClassTesting2<TextStyle>,
     public void testSetOrRemoveNullValue() {
         final TextStyle style = TextStyle.EMPTY
                 .set(TextStylePropertyName.BACKGROUND_COLOR, Color.BLACK);
+        this.setOrRemoveAndCheck(
+                style,
+                TextStylePropertyName.BACKGROUND_COLOR,
+                null,
+                style.remove(TextStylePropertyName.BACKGROUND_COLOR)
+        );
+    }
+
+    private <T> void setOrRemoveAndCheck(final TextStyle style,
+                                         final TextStylePropertyName<T> name,
+                                         final T value,
+                                         final TextStyle expected) {
         this.checkEquals(
-                style.remove(TextStylePropertyName.BACKGROUND_COLOR),
-                style.setOrRemove(TextStylePropertyName.BACKGROUND_COLOR, null)
+                expected,
+                style.setOrRemove(name, value),
+                style + " setOrRemove " + name + " " + value
         );
     }
 
@@ -275,6 +313,26 @@ public final class TextStyleTest implements ClassTesting2<TextStyle>,
     }
 
     @Test
+    public void testPatchSetAllWithNonNullFails() {
+        final UnsupportedOperationException thrown = assertThrows(
+                UnsupportedOperationException.class,
+                () -> TextStyle.EMPTY.patch(
+                        JsonNode.object()
+                                .set(
+                                        JsonPropertyName.with(TextStylePropertyName.ALL.value()),
+                                        JsonNode.string("This must fail!")
+                                ),
+                        this.createPatchContext()
+                )
+        );
+        this.checkEquals(
+                "Unmarshalling \"*\" with \"This must fail!\" is not supported",
+                thrown.getMessage(),
+                "message"
+        );
+    }
+
+    @Test
     public void testPatchRemoveUnknownProperty() {
         this.patchAndCheck(
                 TextStyle.EMPTY,
@@ -300,6 +358,29 @@ public final class TextStyleTest implements ClassTesting2<TextStyle>,
                         .set(TextStylePropertyName.BACKGROUND_COLOR, Color.BLACK),
                 JsonNode.object()
                         .set(JsonPropertyName.with(TextStylePropertyName.BACKGROUND_COLOR.value()), JsonNode.nullNode()),
+                TextStyle.EMPTY
+        );
+    }
+
+    @Test
+    public void testPatchRemovePropertyAll() {
+        this.patchAndCheck(
+                TextStyle.EMPTY
+                        .set(TextStylePropertyName.BACKGROUND_COLOR, Color.BLACK),
+                JsonNode.object()
+                        .set(JsonPropertyName.with(TextStylePropertyName.ALL.value()), JsonNode.nullNode()),
+                TextStyle.EMPTY
+        );
+    }
+
+    @Test
+    public void testPatchRemovePropertyAllManyValues() {
+        this.patchAndCheck(
+                TextStyle.EMPTY
+                        .set(TextStylePropertyName.BACKGROUND_COLOR, Color.BLACK)
+                        .set(TextStylePropertyName.COLOR, Color.WHITE),
+                JsonNode.object()
+                        .set(JsonPropertyName.with(TextStylePropertyName.ALL.value()), JsonNode.nullNode()),
                 TextStyle.EMPTY
         );
     }

--- a/src/test/java/walkingkooka/tree/text/TextStyleTestCase.java
+++ b/src/test/java/walkingkooka/tree/text/TextStyleTestCase.java
@@ -182,10 +182,28 @@ public abstract class TextStyleTestCase<T extends TextStyle> implements ClassTes
 
     @Test
     public final void testSetInvalidPropertyValueFails() {
-        assertThrows(TextStylePropertyValueException.class, () -> {
-            final TextStylePropertyName<?> propertyName = TextStylePropertyName.FONT_FAMILY;
-            this.createObject().set(propertyName, Cast.to("invalid"));
-        });
+        assertThrows(
+                TextStylePropertyValueException.class,
+                () -> {
+                    final TextStylePropertyName<?> propertyName = TextStylePropertyName.FONT_FAMILY;
+                    this.createObject().set(propertyName, Cast.to("invalid"));
+                }
+        );
+    }
+
+    @Test
+    public final void testSetAllFails() {
+        assertThrows(
+                TextStylePropertyValueException.class,
+                () -> {
+                    final TextStylePropertyName<?> propertyName = TextStylePropertyName.ALL;
+                    this.createObject()
+                            .set(
+                                    propertyName,
+                                    Cast.to("Invalid")
+                            );
+                }
+        );
     }
 
     final <TT> TextStyle setAndCheck(final TextStyle textStyle,


### PR DESCRIPTION
- TextStyle.set(TextStylePropertyName.ALL, <any>) will always fail.
- TextStyle.remove(TextStyleProperty.ALL) always returns TextStyle.EMPTY