### PR TITLE
TextStylePropertyName: json-property-name camelCase was kebab

### DIFF
--- a/src/main/java/walkingkooka/tree/text/TextStylePropertyName.java
+++ b/src/main/java/walkingkooka/tree/text/TextStylePropertyName.java
@@ -25,6 +25,7 @@ import walkingkooka.color.Color;
 import walkingkooka.naming.Name;
 import walkingkooka.net.HasUrlFragment;
 import walkingkooka.net.UrlFragment;
+import walkingkooka.text.CaseKind;
 import walkingkooka.text.CaseSensitivity;
 import walkingkooka.text.CharSequences;
 import walkingkooka.tree.json.JsonNode;
@@ -784,7 +785,12 @@ public final class TextStylePropertyName<T> extends TextNodeNameName<TextStylePr
         this.visitor = visitor;
 
         this.urlFragment = UrlFragment.with(name);
-        this.jsonPropertyName = JsonPropertyName.with(this.name);
+        this.jsonPropertyName = JsonPropertyName.with(
+            CaseKind.KEBAB.change(
+                name,
+                CaseKind.CAMEL
+            )
+        );
         this.patchRemove = JsonNode.object()
             .set(
                 this.jsonPropertyName,
@@ -848,12 +854,26 @@ public final class TextStylePropertyName<T> extends TextNodeNameName<TextStylePr
     // JsonNodeContext..................................................................................................
 
     static TextStylePropertyName<?> unmarshall(final JsonNode node) {
-        return with(node.name().value());
+        return unmarshall(
+            node.name()
+                .value()
+        );
     }
 
     static TextStylePropertyName<?> unmarshall(final JsonNode node,
                                                final JsonNodeUnmarshallContext context) {
-        return with(node.stringOrFail());
+        return unmarshall(
+            node.stringOrFail()
+        );
+    }
+
+    private static TextStylePropertyName<?> unmarshall(final String value) {
+        return with(
+            CaseKind.CAMEL.change(
+                value,
+                CaseKind.KEBAB
+            )
+        );
     }
 
     JsonPropertyName marshallName() {

--- a/src/test/java/walkingkooka/tree/text/TextStyleNodeTest.java
+++ b/src/test/java/walkingkooka/tree/text/TextStyleNodeTest.java
@@ -385,7 +385,7 @@ public final class TextStyleNodeTest extends TextParentNodeTestCase<TextStyleNod
     public void testMarshallWithStyleNode() {
         this.marshallAndCheck(textStyleNode()
                 .setAttributes(Maps.of(TextStylePropertyName.BACKGROUND_COLOR, Color.fromRgb(0x123456))),
-            "{\"styles\": {\"background-color\": \"#123456\"}}");
+            "{\"styles\": {\"backgroundColor\": \"#123456\"}}");
     }
 
     @Test
@@ -398,7 +398,7 @@ public final class TextStyleNodeTest extends TextParentNodeTestCase<TextStyleNod
                         Color.fromRgb(0x123456)
                     )
                 ),
-            "{\"styles\": {\"background-color\": \"#123456\"}, \"children\": [{\"type\": \"text\", \"value\": \"text123\"}]}"
+            "{\"styles\": {\"backgroundColor\": \"#123456\"}, \"children\": [{\"type\": \"text\", \"value\": \"text123\"}]}"
         );
     }
 

--- a/src/test/java/walkingkooka/tree/text/TextStylePropertyNameTest.java
+++ b/src/test/java/walkingkooka/tree/text/TextStylePropertyNameTest.java
@@ -24,6 +24,7 @@ import walkingkooka.collect.set.SortedSets;
 import walkingkooka.color.Color;
 import walkingkooka.net.UrlFragment;
 import walkingkooka.reflect.FieldAttributes;
+import walkingkooka.text.CaseKind;
 import walkingkooka.text.CaseSensitivity;
 import walkingkooka.text.CharSequences;
 import walkingkooka.tree.expression.ExpressionNumberKind;
@@ -236,7 +237,7 @@ public final class TextStylePropertyNameTest extends TextNodeNameNameTestCase<Te
             TextAlign.RIGHT,
             JsonNode.object()
                 .set(
-                    JsonPropertyName.with("text-align"),
+                    JsonPropertyName.with("textAlign"),
                     JsonNode.string("RIGHT")
                 )
         );
@@ -287,7 +288,7 @@ public final class TextStylePropertyNameTest extends TextNodeNameNameTestCase<Te
             propertyValue,
             JsonNode.object()
                 .set(
-                    JsonPropertyName.with("border-color"),
+                    JsonPropertyName.with("borderColor"),
                     JsonNode.string(propertyValue.toString())
                 )
         );
@@ -316,7 +317,7 @@ public final class TextStylePropertyNameTest extends TextNodeNameNameTestCase<Te
             null,
             JsonNode.object()
                 .set(
-                    JsonPropertyName.with("text-align"),
+                    JsonPropertyName.with("textAlign"),
                     JsonNode.nullNode()
                 )
         );
@@ -359,7 +360,12 @@ public final class TextStylePropertyNameTest extends TextNodeNameNameTestCase<Te
                 null,
                 JsonNode.object()
                     .set(
-                        JsonPropertyName.with(propertyName.name),
+                        JsonPropertyName.with(
+                            CaseKind.KEBAB.change(
+                                propertyName.name,
+                                CaseKind.CAMEL
+                            )
+                        ),
                         JsonNode.nullNode()
                     )
             );

--- a/src/test/java/walkingkooka/tree/text/TextStylePropertyValueTestCase.java
+++ b/src/test/java/walkingkooka/tree/text/TextStylePropertyValueTestCase.java
@@ -47,7 +47,12 @@ public abstract class TextStylePropertyValueTestCase<V> implements ClassTesting2
     @Test
     public final void testTextStylePropertyJsonRoundtrip() {
         final TextNode properties = TextNode.style(TextStyleNode.NO_CHILDREN)
-            .setAttributes(Maps.of(this.textStylePropertyName(), this.createTextStylePropertyValue()));
+            .setAttributes(
+                Maps.of(
+                    this.textStylePropertyName(),
+                    this.createTextStylePropertyValue()
+                )
+            );
         final JsonNode json = JsonNodeMarshallContexts.basic().marshallWithType(properties);
         this.checkEquals(
             properties,


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-tree-text/issues/293
- TextStylePropertyName json property names should be camelcase not snake