### PR TITLE
ToStyleableConverter support first parameter text FIX

### DIFF
--- a/src/main/java/walkingkooka/tree/text/convert/ToStyleableConverter.java
+++ b/src/main/java/walkingkooka/tree/text/convert/ToStyleableConverter.java
@@ -22,6 +22,7 @@ import walkingkooka.convert.Converter;
 import walkingkooka.convert.ConverterContext;
 import walkingkooka.convert.TryingShortCircuitingConverter;
 import walkingkooka.tree.text.Styleable;
+import walkingkooka.tree.text.TextStyle;
 
 /**
  * A {@link Converter} that accepts converts an object if it implements {@link Styleable}.
@@ -48,7 +49,11 @@ final class ToStyleableConverter<C extends ConverterContext> implements TryingSh
     public boolean canConvert(final Object value,
                               final Class<?> type,
                               final C context) {
-        return value instanceof Styleable && Styleable.class == type;
+        return value instanceof Styleable && Styleable.class == type ||
+            value instanceof CharSequence && context.canConvert(
+                value,
+                TextStyle.class
+            );
     }
 
 
@@ -56,7 +61,12 @@ final class ToStyleableConverter<C extends ConverterContext> implements TryingSh
     public Styleable tryConvertOrFail(final Object value,
                                       final Class<?> type,
                                       final C context) {
-        return (Styleable) value;
+        return value instanceof CharSequence ?
+            context.convertOrFail(
+                value,
+                TextStyle.class
+            ) :
+            (Styleable) value;
     }
 
     // Object...........................................................................................................

--- a/src/test/java/walkingkooka/tree/text/convert/ToStyleableConverterTest.java
+++ b/src/test/java/walkingkooka/tree/text/convert/ToStyleableConverterTest.java
@@ -19,9 +19,12 @@ package walkingkooka.tree.text.convert;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.Cast;
+import walkingkooka.Either;
 import walkingkooka.ToStringTesting;
-import walkingkooka.convert.ConverterContexts;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.convert.Converter;
 import walkingkooka.convert.ConverterTesting2;
+import walkingkooka.convert.Converters;
 import walkingkooka.convert.FakeConverterContext;
 import walkingkooka.tree.text.Styleable;
 import walkingkooka.tree.text.TextAlign;
@@ -34,9 +37,12 @@ public final class ToStyleableConverterTest implements ConverterTesting2<ToStyle
 
     @Test
     public void testStringToStyleable() {
-        this.convertFails(
-            "Hello",
-            Styleable.class
+        final String text = "color: #111";
+
+        this.convertAndCheck(
+            text,
+            Styleable.class,
+            TextStyle.parse(text)
         );
     }
 
@@ -68,7 +74,35 @@ public final class ToStyleableConverterTest implements ConverterTesting2<ToStyle
 
     @Override
     public FakeConverterContext createContext() {
-        return (FakeConverterContext) ConverterContexts.fake();
+        return new FakeConverterContext() {
+
+            @Override
+            public boolean canConvert(final Object value,
+                                      final Class<?> type) {
+                return this.converter.canConvert(
+                    value,
+                    type,
+                    this
+                );
+            }
+
+            @Override
+            public <T> Either<T, String> convert(final Object value,
+                                                 final Class<T> target) {
+                return this.converter.convert(
+                    value,
+                    target,
+                    this
+                );
+            }
+
+            private final Converter<FakeConverterContext> converter = Converters.collection(
+                Lists.of(
+                    Converters.characterOrCharSequenceOrHasTextOrStringToCharacterOrCharSequenceOrString(),
+                    TreeTextConverters.textToTextStyle()
+                )
+            );
+        };
     }
 
     // toString.........................................................................................................

--- a/src/test/java/walkingkooka/tree/text/expression/function/TreeTextExpressionFunctionsTest.java
+++ b/src/test/java/walkingkooka/tree/text/expression/function/TreeTextExpressionFunctionsTest.java
@@ -177,6 +177,21 @@ public final class TreeTextExpressionFunctionsTest implements PublicStaticHelper
     }
 
     @Test
+    public void testMergeStyleWithStringAndString() {
+        final String style1 = "background-color: #111;";
+        final String style2 = "color: #222;";
+
+        this.evaluateAndCheck(
+            "mergeStyle",
+            Lists.of(
+                style1,
+                style2
+            ),
+            TextStyle.parse(style1 + style2)
+        );
+    }
+
+    @Test
     public void testMergeStyleWithTextAndTextStyleAndTextStyle() {
         final TextStyle textStyle = TextStyle.parse("background-color: #111;");
         final TextStyle mergeWithTextStyle = TextStyle.parse("color: #222;");
@@ -192,7 +207,7 @@ public final class TreeTextExpressionFunctionsTest implements PublicStaticHelper
     }
 
     @Test
-    public void testMergeStyleWithStringAndString() {
+    public void testMergeStyleWithTextNodeAndString() {
         final TextNode text = TextNode.text("HelloText123");
         final String style = "text-align: left; color: #999;";
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-tree-text/issues/448
- ExpressionFunction: TreeTextExpressionFunctionMergeStyle first parameter of String should work