### PR TITLE
TextLeafNode.isEmpty FIX

### DIFF
--- a/src/main/java/walkingkooka/tree/text/TextLeafNode.java
+++ b/src/main/java/walkingkooka/tree/text/TextLeafNode.java
@@ -164,4 +164,14 @@ abstract class TextLeafNode<V> extends TextNode implements Value<V> {
             hasValue.value()
         );
     }
+
+    // CanBeEmpty.......................................................................................................
+
+    /**
+     * Sub-classes like {@link Image} are not empty, {@link Text} is only empty if it has no text.
+     */
+    @Override
+    public final boolean isEmpty() {
+        return "".equals(this.value); // only empty string is considered empty, Image etc are not
+    }
 }

--- a/src/test/java/walkingkooka/tree/text/ImageTest.java
+++ b/src/test/java/walkingkooka/tree/text/ImageTest.java
@@ -184,6 +184,16 @@ public final class ImageTest extends TextLeafNodeTestCase<Image, Url> {
         return Image.unmarshallImage(from, context);
     }
 
+    // canBeEmpty.......................................................................................................
+
+    @Test
+    public void testIsEmptyWhenEMPTY() {
+        this.isEmptyAndCheck(
+            this.createTextNode(),
+            false
+        );
+    }
+
     // typeNaming.......................................................................................................
 
     @Override

--- a/src/test/java/walkingkooka/tree/text/TextPlaceholderNodeTest.java
+++ b/src/test/java/walkingkooka/tree/text/TextPlaceholderNodeTest.java
@@ -161,6 +161,16 @@ public final class TextPlaceholderNodeTest extends TextLeafNodeTestCase<TextPlac
         return TextPlaceholderNode.class;
     }
 
+    // canBeEmpty.......................................................................................................
+
+    @Test
+    public void testIsEmptyWhenEMPTY() {
+        this.isEmptyAndCheck(
+            this.createTextNode(),
+            false
+        );
+    }
+
     // JsonNodeMarshallingTesting........................................................................................
 
     @Override

--- a/src/test/java/walkingkooka/tree/text/TextTest.java
+++ b/src/test/java/walkingkooka/tree/text/TextTest.java
@@ -395,6 +395,24 @@ public final class TextTest extends TextLeafNodeTestCase<Text, String> {
         return Text.unmarshallText(from, context);
     }
 
+    // canBeEmpty.......................................................................................................
+
+    @Test
+    public void testIsEmptyWhenEMPTY() {
+        this.isEmptyAndCheck(
+            Text.EMPTY_TEXT,
+            true
+        );
+    }
+
+    @Test
+    public void testIsEmptyWhenNonEmptyString() {
+        this.isEmptyAndCheck(
+            Text.with("Hello"),
+            false
+        );
+    }
+
     // class............................................................................................................
 
     @Override


### PR DESCRIPTION
- Previously TextNode with text were skipped by ComponentWithChildren#printTreeChildren becaues TextNode.isEmpty was always returning true