### PR TITLE
TextStylePropertyName.index

### DIFF
--- a/src/main/java/walkingkooka/tree/text/TextStylePropertyName.java
+++ b/src/main/java/walkingkooka/tree/text/TextStylePropertyName.java
@@ -158,7 +158,8 @@ public final class TextStylePropertyName<T> extends TextNodeNameName<TextStylePr
         final TextStylePropertyName<T> textStylePropertyName = new TextStylePropertyName<>(
             property,
             handler,
-            visitor
+            visitor,
+            TextStylePropertyName.CONSTANTS.size() - 1// index wildcard will be given a value of -1, BACKGROUND_COLOR=0 etc.
         );
         TextStylePropertyName.CONSTANTS.put(
             property,
@@ -877,7 +878,8 @@ public final class TextStylePropertyName<T> extends TextNodeNameName<TextStylePr
 
     private TextStylePropertyName(final String name,
                                   final TextStylePropertyValueHandler<T> handler,
-                                  final BiConsumer<T, TextStyleVisitor> visitor) {
+                                  final BiConsumer<T, TextStyleVisitor> visitor,
+                                  final int index) {
         super(name);
         this.handler = handler;
         this.visitor = visitor;
@@ -893,6 +895,8 @@ public final class TextStylePropertyName<T> extends TextNodeNameName<TextStylePr
             .setNull(
                 this.jsonPropertyName
             );
+
+        this.index = index;
     }
 
     /**
@@ -952,6 +956,12 @@ public final class TextStylePropertyName<T> extends TextNodeNameName<TextStylePr
     CharSequence inQuotes() {
         return CharSequences.quoteAndEscape(this.name);
     }
+
+    /**
+     * Unique index allocated to each {@link TextStylePropertyName} intended to be used as an index into an array of values
+     * {@link TextStylePropertyName}.
+     */
+    final int index;
 
     // HasUrlFragment...................................................................................................
 

--- a/src/test/java/walkingkooka/tree/text/TextStylePropertyNameTest.java
+++ b/src/test/java/walkingkooka/tree/text/TextStylePropertyNameTest.java
@@ -42,6 +42,35 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 
 public final class TextStylePropertyNameTest extends TextNodeNameNameTestCase<TextStylePropertyName<?>> {
 
+    // index............................................................................................................
+
+    @Test
+    public void testIndexWithWildcard() {
+        this.indexAndCheck(
+            TextStylePropertyName.WILDCARD,
+            -1
+        );
+    }
+
+    @Test
+    public void testIndexWithBackgroundColor() {
+        this.indexAndCheck(
+            TextStylePropertyName.BACKGROUND_COLOR,
+            0
+        );
+    }
+
+    private void indexAndCheck(final TextStylePropertyName<?> propertyName,
+                               final int expected) {
+        this.checkEquals(
+            expected,
+            propertyName.index,
+            propertyName::toString
+        );
+    }
+
+    // constants........................................................................................................
+
     @Test
     public void testConstants() {
         this.checkEquals(Lists.empty(),


### PR DESCRIPTION
- First step towards a TextStylePropertyMap that only holds values in an array using TextStylePropertyName.index as the array element selector(index)