### PR TITLE
TextStyleNonEmpty.merge(TextStyleNonEmpty) FIX

### DIFF
--- a/src/main/java/walkingkooka/tree/text/TextStyleNonEmpty.java
+++ b/src/main/java/walkingkooka/tree/text/TextStyleNonEmpty.java
@@ -111,39 +111,34 @@ final class TextStyleNonEmpty extends TextStyle {
             afterSize
         );
 
+        boolean different = false;
+        int newCount = 0;
+
         final Object[] newValues = new Object[newSize];
 
-        // copy before
-        System.arraycopy(
-            beforeValues,
-            0,
-            newValues,
-            0,
-            beforeSize
-        );
+        for(int i = 0; i < newSize; i++) {
+            final Object beforeValue = i < beforeSize ?
+                beforeValues[i] :
+                null;
 
-        boolean different = false;
-        int newCount = before.count;
+            final Object afterValue = i < afterSize ?
+                afterValues[i] :
+                null;
 
-        for (int i = 0; i < afterSize; i++) {
-            final Object afterValue = afterValues[i];
-            if(null == afterValue) {
-                continue;
-            }
+            Object newValue = afterValue;
+            if(null != newValue) {
+                different = different | false == newValue.equals(beforeValue);
+                newCount++;
+            } else {
+                newValue = beforeValue;
 
-            if(i < beforeSize) {
-                final Object beforeValue = newValues[i];
-                if (afterValue.equals(beforeValue)) {
-                    continue;
-                }
-                if(null != beforeValue) {
-                    newCount--;
+                if(null != newValue) {
+                    newCount++;
+                    different = true;
                 }
             }
 
-            different = true;
-            newValues[i] = afterValue;
-            newCount++;
+            newValues[i] = newValue;
         }
 
         return different ?

--- a/src/test/java/walkingkooka/tree/text/TextStyleNonEmptyTest.java
+++ b/src/test/java/walkingkooka/tree/text/TextStyleNonEmptyTest.java
@@ -152,6 +152,24 @@ public final class TextStyleNonEmptyTest extends TextStyleTestCase<TextStyleNonE
         );
     }
 
+    @Test
+    public void testMergeWithNotEmptyWithDifferent9() {
+        this.mergeAndCheck(
+            TextStyle.parse("font-weight: bold;"),
+            TextStyle.parse("background-color: #111; color: #222; font-weight: bold; text-align: left"),
+            TextStyle.parse("background-color: #111; color: #222; font-weight: bold; text-align: left")
+        );
+    }
+
+    @Test
+    public void testMergeWithNotEmptyWithDifferent10() {
+        this.mergeAndCheck(
+            TextStyle.parse("background-color: #111; color: #222; font-weight: bold; text-align: left"),
+            TextStyle.parse("font-weight: bold;"),
+            TextStyle.parse("background-color: #111; color: #222; font-weight: bold; text-align: left")
+        );
+    }
+
     // replace...........................................................................................................
 
     @Test


### PR DESCRIPTION
- Previously if the new TextStyle included all the TextStyle without any missing, it would return the old with less properties.