### PR TITLE
TextStylePropertyName.type() was valueType

### DIFF
--- a/src/main/java/walkingkooka/tree/text/TextStylePropertyName.java
+++ b/src/main/java/walkingkooka/tree/text/TextStylePropertyName.java
@@ -959,7 +959,7 @@ public final class TextStylePropertyName<T> extends TextNodeNameName<TextStylePr
     /**
      * Returns the {@link Class} of the value type. This can be used an an argument to a {@link walkingkooka.convert.Converter}.
      */
-    public Class<T> valueType() {
+    public Class<T> type() {
         return this.handler.valueType();
     }
 

--- a/src/main/java/walkingkooka/tree/text/TextStylePropertyValueHandler.java
+++ b/src/main/java/walkingkooka/tree/text/TextStylePropertyValueHandler.java
@@ -119,7 +119,7 @@ abstract class TextStylePropertyValueHandler<T> {
     }
 
     /**
-     * {@link TextStylePropertyName#valueType()}
+     * {@link TextStylePropertyName#type()}
      */
     abstract Class<T> valueType();
 

--- a/src/test/java/walkingkooka/tree/text/expression/function/TreeTextExpressionFunctionsTest.java
+++ b/src/test/java/walkingkooka/tree/text/expression/function/TreeTextExpressionFunctionsTest.java
@@ -557,8 +557,8 @@ public final class TreeTextExpressionFunctionsTest implements PublicStaticHelper
 
             final Object propertyValue;
 
-            final Class<?> valueType = propertyName.valueType();
-            switch (valueType.getSimpleName()) {
+            final Class<?> type = propertyName.type();
+            switch (type.getSimpleName()) {
                 case "Color":
                     propertyValue = Color.BLACK;
                     break;
@@ -585,19 +585,19 @@ public final class TreeTextExpressionFunctionsTest implements PublicStaticHelper
                     break;
 
                 default:
-                    if (valueType.isEnum()) {
+                    if (type.isEnum()) {
                         final Enum[] enums = (Enum[])
-                            valueType.getMethod("values")
+                            type.getMethod("values")
                                 .invoke(null);
                         propertyValue = enums[0];
                         break;
                     }
 
-                    throw new UnsupportedOperationException(propertyName + " " + propertyName.valueType().getSimpleName());
+                    throw new UnsupportedOperationException(propertyName + " " + propertyName.type().getSimpleName());
             }
 
             String propertyValueText = propertyValue.toString();
-            if (valueType == Opacity.class) {
+            if (type == Opacity.class) {
                 propertyValueText = Opacity.with(0.5).text();
             }
 


### PR DESCRIPTION
- Will be required when ValueName interface introduced and implemented by TextStylePropertyName & SpreadsheetMetadataPropertyName