### PR TITLE
TextStylePropertiesMapMutable

### DIFF
--- a/src/main/java/walkingkooka/tree/text/TextStyleNonEmpty.java
+++ b/src/main/java/walkingkooka/tree/text/TextStyleNonEmpty.java
@@ -19,7 +19,6 @@ package walkingkooka.tree.text;
 
 import walkingkooka.Cast;
 import walkingkooka.collect.list.Lists;
-import walkingkooka.collect.map.Maps;
 import walkingkooka.naming.Name;
 import walkingkooka.text.CaseKind;
 import walkingkooka.text.CharSequences;
@@ -71,8 +70,18 @@ final class TextStyleNonEmpty extends TextStyle {
 
     @Override
     Map<TextStylePropertyName<?>, Object> valuesMutableCopy() {
-        final Map<TextStylePropertyName<?>, Object> copy = Maps.sorted();
-        copy.putAll(this.value);
+        final TextStylePropertiesMapEntrySet entries = this.value.entries;
+
+        // "clone" the values faster than putAll
+        final TextStylePropertiesMapMutable copy = TextStylePropertiesMapMutable.empty();
+        copy.size = entries.count;
+        System.arraycopy(
+            entries.values,
+            0,
+            copy.values,
+            0,
+            entries.values.length
+        );
         return copy;
     }
 

--- a/src/main/java/walkingkooka/tree/text/TextStylePropertiesMap.java
+++ b/src/main/java/walkingkooka/tree/text/TextStylePropertiesMap.java
@@ -55,30 +55,52 @@ final class TextStylePropertiesMap extends AbstractMap<TextStylePropertyName<?>,
         if (map instanceof TextStylePropertiesMap) {
             textStylePropertiesMap = (TextStylePropertiesMap) map;
         } else {
-            int count = 0;
-            final List<Object> values = Lists.autoExpandArray();
+            if(map instanceof TextStylePropertiesMapMutable) {
+                final TextStylePropertiesMapMutable textStylePropertiesMapMutable = (TextStylePropertiesMapMutable) map;
 
-            for (final Entry<TextStylePropertyName<?>, Object> entry : map.entrySet()) {
-                final TextStylePropertyName<?> propertyName = entry.getKey();
-                final int index = propertyName.index();
-
-                final Object value = entry.getValue();
-                propertyName.checkValue(value);
-
-                values.set(
-                    index,
-                    entry.getValue()
+                // not required, but taking a copy just to be safe
+                final Object[] array = textStylePropertiesMapMutable.values;
+                final Object[] copy = new Object[array.length];
+                System.arraycopy(
+                    array,
+                    0,
+                    copy,
+                    0,
+                    array.length
                 );
 
-                count++;
-            }
+                textStylePropertiesMap = TextStylePropertiesMap.withTextStyleMapEntrySet(
+                    TextStylePropertiesMapEntrySet.with(
+                        copy,
+                        textStylePropertiesMapMutable.size()
+                    )
+                );
+            } else {
+                int count = 0;
+                final List<Object> values = Lists.autoExpandArray();
 
-            textStylePropertiesMap = withTextStyleMapEntrySet(
-                TextStylePropertiesMapEntrySet.with(
-                    values.toArray(),
-                    count
-                )
-            );
+                for (final Entry<TextStylePropertyName<?>, Object> entry : map.entrySet()) {
+                    final TextStylePropertyName<?> propertyName = entry.getKey();
+                    final int index = propertyName.index();
+
+                    final Object value = entry.getValue();
+                    propertyName.checkValue(value);
+
+                    values.set(
+                        index,
+                        entry.getValue()
+                    );
+
+                    count++;
+                }
+
+                textStylePropertiesMap = withTextStyleMapEntrySet(
+                    TextStylePropertiesMapEntrySet.with(
+                        values.toArray(),
+                        count
+                    )
+                );
+            }
         }
 
         return textStylePropertiesMap;

--- a/src/main/java/walkingkooka/tree/text/TextStylePropertiesMapMutable.java
+++ b/src/main/java/walkingkooka/tree/text/TextStylePropertiesMapMutable.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.text;
+
+import walkingkooka.CanBeEmpty;
+
+import java.util.AbstractMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * A mutable {@link Map} that is backed by an array and is used by {@link TextStyle} when processing a few set/remove operations.
+ */
+final class TextStylePropertiesMapMutable extends AbstractMap<TextStylePropertyName<?>, Object> implements CanBeEmpty {
+
+    static TextStylePropertiesMapMutable empty() {
+        return new TextStylePropertiesMapMutable();
+    }
+
+    private TextStylePropertiesMapMutable() {
+        super();
+        this.values = new Object[TextStylePropertyName.NAMES.length];
+        this.size = 0;
+    }
+
+    @Override
+    public int size() {
+        return this.size;
+    }
+
+    int size;
+
+    @Override
+    public Object get(final Object name) {
+        return name instanceof TextStylePropertyName ?
+            this.getTextStylePropertyName(
+                (TextStylePropertyName) name) :
+            null;
+    }
+
+    private Object getTextStylePropertyName(final TextStylePropertyName<?> name) {
+        return this.values[name.index];
+    }
+
+    @Override
+    public Object put(final TextStylePropertyName<?> name, final Object value) {
+        Objects.requireNonNull(name, "name");
+
+        final int index = name.index;
+
+        Object old = this.values[index];
+        name.checkValue(value);
+        this.values[index] = value;
+
+        if (null == old) {
+            this.size++;
+        }
+
+        return old;
+    }
+
+    final Object[] values;
+
+    @Override
+    public Set<Entry<TextStylePropertyName<?>, Object>> entrySet() {
+        return TextStylePropertiesMapEntrySet.with(
+            this.values,
+            this.size
+        );
+    }
+}

--- a/src/test/java/walkingkooka/tree/text/TextStylePropertiesMapMutableTest.java
+++ b/src/test/java/walkingkooka/tree/text/TextStylePropertiesMapMutableTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.text;
+
+import walkingkooka.reflect.ClassTesting;
+import walkingkooka.reflect.JavaVisibility;
+
+public final class TextStylePropertiesMapMutableTest implements ClassTesting<TextStylePropertiesMapMutable> {
+
+    @Override
+    public Class<TextStylePropertiesMapMutable> type() {
+        return TextStylePropertiesMapMutable.class;
+    }
+
+    @Override
+    public JavaVisibility typeVisibility() {
+        return JavaVisibility.PACKAGE_PRIVATE;
+    }
+}


### PR DESCRIPTION
- Replaces the temp Map used by TextStyle.
- Appears to make GWT viewport rendering about 3ish times faster
- TODO TextStyleNonEmpty#removeNonNull