### PR TITLE
TextStyle.parse non empty TextCursor report InvalidCharacterException

### DIFF
--- a/src/main/java/walkingkooka/tree/text/TextStyle.java
+++ b/src/main/java/walkingkooka/tree/text/TextStyle.java
@@ -102,6 +102,11 @@ public abstract class TextStyle implements Value<Map<TextStylePropertyName<?>, O
 
             final Optional<TextStylePropertyName<?>> maybeName = parser.name();
             if(false == maybeName.isPresent()) {
+                if(parser.isNotEmpty()) {
+                    throw parser.cursor.lineInfo()
+                        .invalidCharacterException()
+                        .get();
+                }
                 break;
             }
 

--- a/src/test/java/walkingkooka/tree/text/TextStyleTest.java
+++ b/src/test/java/walkingkooka/tree/text/TextStyleTest.java
@@ -722,6 +722,18 @@ public final class TextStyleTest implements ClassTesting2<TextStyle>,
     }
 
     @Test
+    public void testParseToStringFails() {
+        final TextStyle style = TextStyle.EMPTY.set(
+            TextStylePropertyName.TEXT_ALIGN,
+            TextAlign.LEFT
+        );
+        this.parseStringInvalidCharacterFails(
+            style.toString(),
+            '{'
+        );
+    }
+
+    @Test
     public void testParseStringEmpty() {
         this.parseStringAndCheck(
             "",

--- a/src/test/java/walkingkooka/tree/text/convert/TreeTextConvertersTest.java
+++ b/src/test/java/walkingkooka/tree/text/convert/TreeTextConvertersTest.java
@@ -55,7 +55,7 @@ public final class TreeTextConvertersTest implements PublicStaticHelperTesting<T
 
     @Test
     public void testConvertStringToTextStyle() {
-        final TextStyle textStyle = TextStyle.parse("{color:red};");
+        final TextStyle textStyle = TextStyle.parse("color:red;");
 
         this.convertAndCheck(
             textStyle.text(),
@@ -66,7 +66,7 @@ public final class TreeTextConvertersTest implements PublicStaticHelperTesting<T
 
     @Test
     public void testConvertTextStyleToTextStyle() {
-        final TextStyle textStyle = TextStyle.parse("{color:red};");
+        final TextStyle textStyle = TextStyle.parse("color:red;");
 
         this.convertAndCheck(
             textStyle,


### PR DESCRIPTION
- Previously parsing css with open/closing braces would return TextStyle.EMPTY and not an InvalidCharacterException