### PR TITLE
BorderMarginPadding.text()

### DIFF
--- a/src/main/java/walkingkooka/tree/text/Border.java
+++ b/src/main/java/walkingkooka/tree/text/Border.java
@@ -97,4 +97,11 @@ public final class Border extends BorderMarginPadding {
             textStyle
         );
     }
+
+    // HasText..........................................................................................................
+
+    @Override
+    int textPrefixLength() {
+        return 7; // "border-".length
+    }
 }

--- a/src/main/java/walkingkooka/tree/text/BorderMarginPadding.java
+++ b/src/main/java/walkingkooka/tree/text/BorderMarginPadding.java
@@ -157,15 +157,52 @@ abstract class BorderMarginPadding implements HasTextStyle,
             this.textStyle.equals(other.textStyle);
     }
 
+    /**
+     * <pre>
+     * border TOP top-color: #123; top-style: solid; top-width: 456px;
+     * </pre>
+     */
     @Override
     public final String toString() {
-        return this.edge + " " + this.textStyle;
+        return this.getClass()
+            .getSimpleName()
+            .toLowerCase() +
+            " " +
+            this.edge +
+            " " +
+            this.text();
     }
 
     // HasText..........................................................................................................
 
+    /**
+     * Returns a text representation without the redundant prefix of border, margin or padding.
+     * <pre>
+     * border-top-color: #111; border-top-style: SOLID; border-top-width: 22px;
+     * top-color: #111; top-style: SOLID; top-width: 22px;
+     *
+     * margin-top: 1px;
+     * top: 1px;
+     * </pre>
+     */
     @Override
-    public String text() {
-        return this.textStyle.text();
+    public final String text() {
+        if (null == this.text) {
+            this.text = this.textStyle.toText(
+                (n) -> n.value()
+                    .substring(
+                        this.textPrefixLength()
+                    )
+            );
+        }
+        return this.text;
     }
+
+    private String text;
+
+    /**
+     * The length of the prefix of each {@link TextStylePropertyName}. This will be used to remove the prefix when
+     * creating the {@link #text()} and {@link #toString()}.
+     */
+    abstract int textPrefixLength();
 }

--- a/src/main/java/walkingkooka/tree/text/Margin.java
+++ b/src/main/java/walkingkooka/tree/text/Margin.java
@@ -70,4 +70,11 @@ public final class Margin extends BorderMarginPadding {
             textStyle
         );
     }
+
+    // HasText..........................................................................................................
+
+    @Override
+    int textPrefixLength() {
+        return 7; // "margin-".length
+    }
 }

--- a/src/main/java/walkingkooka/tree/text/Padding.java
+++ b/src/main/java/walkingkooka/tree/text/Padding.java
@@ -70,4 +70,11 @@ public final class Padding extends BorderMarginPadding {
             textStyle
         );
     }
+
+    // HasText..........................................................................................................
+
+    @Override
+    int textPrefixLength() {
+        return 8; // "padding-".length
+    }
 }

--- a/src/test/java/walkingkooka/tree/text/BorderMarginPaddingTestCase.java
+++ b/src/test/java/walkingkooka/tree/text/BorderMarginPaddingTestCase.java
@@ -24,6 +24,7 @@ import walkingkooka.collect.map.Maps;
 import walkingkooka.color.Color;
 import walkingkooka.reflect.ClassTesting2;
 import walkingkooka.reflect.JavaVisibility;
+import walkingkooka.text.HasTextTesting;
 
 import java.util.Map;
 import java.util.Optional;
@@ -35,7 +36,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public abstract class BorderMarginPaddingTestCase<T extends BorderMarginPadding> implements ClassTesting2<T>,
     HashCodeEqualsDefinedTesting2<T>,
     ToStringTesting<T>,
-    HasTextStyleTesting {
+    HasTextStyleTesting,
+    HasTextTesting {
 
     BorderMarginPaddingTestCase() {
         super();

--- a/src/test/java/walkingkooka/tree/text/BorderTest.java
+++ b/src/test/java/walkingkooka/tree/text/BorderTest.java
@@ -212,7 +212,7 @@ public final class BorderTest extends BorderMarginPaddingTestCase<Border> {
                         TextStylePropertyName.BORDER_RIGHT_STYLE, BorderStyle.DOTTED)
                 )
             ),
-            "BOTTOM {border-right-color=#123456, border-right-style=DOTTED}"
+            "border BOTTOM right-color: #123456; right-style: dotted;"
         );
     }
 
@@ -226,7 +226,7 @@ public final class BorderTest extends BorderMarginPaddingTestCase<Border> {
                         TextStylePropertyName.BORDER_RIGHT_STYLE, BorderStyle.DOTTED)
                 )
             ),
-            "TOP {border-right-color=#123456, border-right-style=DOTTED}"
+            "border TOP right-color: #123456; right-style: dotted;"
         );
     }
 
@@ -238,7 +238,33 @@ public final class BorderTest extends BorderMarginPaddingTestCase<Border> {
                 BorderStyle.DASHED,
                 Length.pixel(2.0)
             ).border(BoxEdge.ALL),
-            "ALL {border-bottom-color=black, border-bottom-style=DASHED, border-bottom-width=2px, border-left-color=black, border-left-style=DASHED, border-left-width=2px, border-right-color=black, border-right-style=DASHED, border-right-width=2px, border-top-color=black, border-top-style=DASHED, border-top-width=2px}"
+            "border ALL bottom-color: black; bottom-style: dashed; bottom-width: 2px; left-color: black; left-style: dashed; left-width: 2px; right-color: black; right-style: dashed; right-width: 2px; top-color: black; top-style: dashed; top-width: 2px;"
+        );
+    }
+
+    // text.............................................................................................................
+
+    @Test
+    public void testTextWithAll() {
+        this.textAndCheck(
+            TextStyle.EMPTY.setBorder(
+                Color.BLACK,
+                BorderStyle.DASHED,
+                Length.pixel(2.0)
+            ).border(BoxEdge.ALL),
+            "bottom-color: black; bottom-style: dashed; bottom-width: 2px; left-color: black; left-style: dashed; left-width: 2px; right-color: black; right-style: dashed; right-width: 2px; top-color: black; top-style: dashed; top-width: 2px;"
+        );
+    }
+
+    @Test
+    public void testTextWithTop() {
+        this.textAndCheck(
+            TextStyle.EMPTY.setBorder(
+                Color.BLACK,
+                BorderStyle.DASHED,
+                Length.pixel(2.0)
+            ).border(BoxEdge.TOP),
+            "top-color: black; top-style: dashed; top-width: 2px;"
         );
     }
 

--- a/src/test/java/walkingkooka/tree/text/MarginTest.java
+++ b/src/test/java/walkingkooka/tree/text/MarginTest.java
@@ -19,22 +19,44 @@ package walkingkooka.tree.text;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.collect.map.Maps;
-import walkingkooka.color.Color;
 
 public final class MarginTest extends BorderMarginPaddingTestCase<Margin> {
 
+    // toString.........................................................................................................
+
     @Test
-    public void testToString() {
+    public void testToStringWithAll() {
         this.toStringAndCheck(
-            Margin.with(BoxEdge.BOTTOM,
+            TextStyle.parse("margin-left: 11px; margin-top: 22px; margin-right: 33px; margin-bottom: 44px;")
+                .margin(BoxEdge.ALL),
+            "margin ALL bottom: 44px; left: 11px; right: 33px; top: 22px;"
+        );
+    }
+    
+    @Test
+    public void testToStringBottom() {
+        this.toStringAndCheck(
+            Margin.with(
+                BoxEdge.BOTTOM,
                 TextStyle.EMPTY.setValues(
                     Maps.of(
-                        TextStylePropertyName.MARGIN_BOTTOM, Length.pixel(12.5),
-                        TextStylePropertyName.COLOR, Color.fromRgb(0x123456)
+                        TextStylePropertyName.MARGIN_BOTTOM, Length.pixel(12.5)
                     )
                 )
             ),
-            "BOTTOM {color=#123456, margin-bottom=12.5px}"
+            "margin BOTTOM bottom: 12.5px;"
+        );
+    }
+
+    // text.............................................................................................................
+
+    @Test
+    public void testText() {
+        this.textAndCheck(
+            TextStyle.EMPTY.setMargin(
+                Length.pixel(2.0)
+            ).margin(BoxEdge.ALL),
+            "bottom: 2px; left: 2px; right: 2px; top: 2px;"
         );
     }
 

--- a/src/test/java/walkingkooka/tree/text/PaddingTest.java
+++ b/src/test/java/walkingkooka/tree/text/PaddingTest.java
@@ -25,16 +25,35 @@ public final class PaddingTest extends BorderMarginPaddingTestCase<Padding> {
     // toString.........................................................................................................
 
     @Test
-    public void testToString() {
+    public void testToStringWithAll() {
         this.toStringAndCheck(
-            Padding.with(BoxEdge.BOTTOM,
-                TextStyle.EMPTY.setValues(
-                    Maps.of(
-                        TextStylePropertyName.PADDING_BOTTOM, Length.pixel(12.5),
-                        TextStylePropertyName.BORDER_RIGHT_STYLE, BorderStyle.DOTTED)
-                )
-            ),
-            "BOTTOM {border-right-style=DOTTED, padding-bottom=12.5px}"
+            TextStyle.parse("padding-left: 11px; padding-top: 22px; padding-right: 33px; padding-bottom: 44px;")
+                .padding(BoxEdge.ALL),
+            "padding ALL bottom: 44px; left: 11px; right: 33px; top: 22px;"
+        );
+    }
+
+    @Test
+    public void testToStringWithBottom() {
+        this.toStringAndCheck(
+            TextStyle.EMPTY.setValues(
+                Maps.of(
+                    TextStylePropertyName.PADDING_BOTTOM, Length.pixel(12.5),
+                    TextStylePropertyName.BORDER_RIGHT_STYLE, BorderStyle.DOTTED)
+            ).padding(BoxEdge.BOTTOM),
+            "padding BOTTOM bottom: 12.5px;"
+        );
+    }
+
+    // text.............................................................................................................
+
+    @Test
+    public void testText() {
+        this.textAndCheck(
+            TextStyle.EMPTY.setPadding(
+                Length.pixel(2.0)
+            ).padding(BoxEdge.ALL),
+            "bottom: 2px; left: 2px; right: 2px; top: 2px;"
         );
     }
 


### PR DESCRIPTION
- Note #text dumps all properties without the "border/margin/padding" prefix

- Closes https://github.com/mP1/walkingkooka-tree-text/issues/629
- Padding implements HasText

- Closes https://github.com/mP1/walkingkooka-tree-text/issues/627
- Margin implements HasText

- Closes https://github.com/mP1/walkingkooka-tree-text/issues/622
- Border implements HasText