### PR TITLE
BorderMarginPadding.removeProperty

### DIFF
--- a/src/main/java/walkingkooka/tree/text/BorderMarginPadding.java
+++ b/src/main/java/walkingkooka/tree/text/BorderMarginPadding.java
@@ -81,6 +81,15 @@ abstract class BorderMarginPadding implements HasTextStyle,
         );
     }
 
+    public final <V> BorderMarginPadding removeProperty(final TextStylePropertyName<V> propertyName) {
+        Objects.requireNonNull(propertyName, "propertyName");
+
+        return this.setOrRemoveProperty(
+            propertyName,
+            Optional.empty()
+        );
+    }
+
     public abstract <V> BorderMarginPadding setOrRemoveProperty(final TextStylePropertyName<V> propertyName,
                                                                 final Optional<V> value);
 

--- a/src/test/java/walkingkooka/tree/text/BorderMarginPaddingTestCase.java
+++ b/src/test/java/walkingkooka/tree/text/BorderMarginPaddingTestCase.java
@@ -266,6 +266,48 @@ public abstract class BorderMarginPaddingTestCase<T extends BorderMarginPadding>
         }
     }
 
+    // removeProperty...................................................................................................
+
+    @Test
+    public final void testRemovePropertyWithNullNameFails() {
+        assertThrows(
+            NullPointerException.class,
+            () -> this.createBorderMarginPadding()
+                .removeProperty(
+                    null
+                )
+        );
+    }
+
+    final <V> void removePropertyAndCheck(final T borderMappingPadding,
+                                          final TextStylePropertyName<V> name) {
+        this.removePropertyAndCheck(
+            borderMappingPadding,
+            name,
+            borderMappingPadding
+        );
+    }
+
+    final <V> void removePropertyAndCheck(final T borderMappingPadding,
+                                          final TextStylePropertyName<V> name,
+                                          final T expected) {
+        if (expected.equals(borderMappingPadding)) {
+            assertSame(
+                expected,
+                borderMappingPadding.removeProperty(name),
+                () -> borderMappingPadding + " removeProperty " + name
+            );
+        } else {
+            this.checkEquals(
+                expected,
+                borderMappingPadding.removeProperty(
+                    name
+                ),
+                () -> borderMappingPadding + " removeProperty " + name
+            );
+        }
+    }
+    
     // setOrRemoveProperty..............................................................................................
 
     @Test

--- a/src/test/java/walkingkooka/tree/text/BorderTest.java
+++ b/src/test/java/walkingkooka/tree/text/BorderTest.java
@@ -222,6 +222,25 @@ public final class BorderTest extends BorderMarginPaddingTestCase<Border> {
         );
     }
 
+    // removeProperty...................................................................................................
+
+    @Test
+    public void testRemovePropertyWithMissing() {
+        this.removePropertyAndCheck(
+            Border.parse("top-color: black;"),
+            TextStylePropertyName.BORDER_TOP_STYLE
+        );
+    }
+
+    @Test
+    public void testRemovePropertyExisting() {
+        this.removePropertyAndCheck(
+            Border.parse("top-color: black; top-style: dashed;"),
+            TextStylePropertyName.BORDER_TOP_STYLE,
+            Border.parse("top-color: black;")
+        );
+    }
+
     // setOrRemoveProperty..............................................................................................
 
     @Test

--- a/src/test/java/walkingkooka/tree/text/MarginTest.java
+++ b/src/test/java/walkingkooka/tree/text/MarginTest.java
@@ -46,6 +46,25 @@ public final class MarginTest extends BorderMarginPaddingTestCase<Margin> {
             Margin.parse("top: 1px; bottom: 2.0px;")
         );
     }
+
+    // removeProperty...................................................................................................
+
+    @Test
+    public void testRemovePropertyMissingProperty() {
+        this.removePropertyAndCheck(
+            Margin.parse("top: 1px;"),
+            TextStylePropertyName.MARGIN_BOTTOM
+        );
+    }
+
+    @Test
+    public void testRemovePropertyExisting() {
+        this.removePropertyAndCheck(
+            Margin.parse("top: 1px; bottom: 2px;"),
+            TextStylePropertyName.MARGIN_BOTTOM,
+            Margin.parse("top: 1px; ")
+        );
+    }
     
     // toString.........................................................................................................
 

--- a/src/test/java/walkingkooka/tree/text/PaddingTest.java
+++ b/src/test/java/walkingkooka/tree/text/PaddingTest.java
@@ -46,6 +46,25 @@ public final class PaddingTest extends BorderMarginPaddingTestCase<Padding> {
             Padding.parse("top: 1px; bottom: 2.0px;")
         );
     }
+
+    // removeProperty...................................................................................................
+
+    @Test
+    public void testRemovePropertyMissingProperty() {
+        this.removePropertyAndCheck(
+            Padding.parse("top: 1px;"),
+            TextStylePropertyName.PADDING_BOTTOM
+        );
+    }
+
+    @Test
+    public void testRemovePropertyExisting() {
+        this.removePropertyAndCheck(
+            Padding.parse("top: 1px; bottom: 2px;"),
+            TextStylePropertyName.PADDING_BOTTOM,
+            Padding.parse("top: 1px; ")
+        );
+    }
     
     // toString.........................................................................................................
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-tree-text/issues/726
- BorderMarginPadding.removeProperty(SpreadsheetNamePropertyName<T>)