### PR TITLE
TextStyle.text() use TextStylePropertyValueHandler for each value

### DIFF
--- a/src/main/java/walkingkooka/tree/text/TextStyleNonEmpty.java
+++ b/src/main/java/walkingkooka/tree/text/TextStyleNonEmpty.java
@@ -19,10 +19,7 @@ package walkingkooka.tree.text;
 
 import walkingkooka.Cast;
 import walkingkooka.collect.list.Lists;
-import walkingkooka.naming.Name;
-import walkingkooka.text.CaseKind;
 import walkingkooka.text.CharSequences;
-import walkingkooka.text.HasText;
 import walkingkooka.text.LineEnding;
 import walkingkooka.text.printer.IndentingPrinter;
 import walkingkooka.text.printer.Printer;
@@ -350,7 +347,10 @@ final class TextStyleNonEmpty extends TextStyle {
                 text.print(" ");
 
                 final Object value = propertyAndValue.getValue();
-                final CharSequence valueCss = toTextValue(value);
+                final CharSequence valueCss = toTextValue(
+                    value,
+                    propertyName.handler
+                );
 
                 text.print(valueCss);
                 text.print(TextStyle.SEPARATOR.string());
@@ -362,29 +362,13 @@ final class TextStyleNonEmpty extends TextStyle {
         return b.toString();
     }
 
-    private static CharSequence toTextValue(final Object value) {
-        final CharSequence text;
-
-        // dont want to handle values such as FontFamily (which implements Name) here.
-        // Name extends HasText
-        if (value instanceof HasText && false == value instanceof Name) {
-            final HasText hasText = (HasText) value;
-            text = hasText.text();
-        } else {
-            if (value instanceof Enum) {
-                final Enum<?> enumEnum = (Enum<?>) value;
-                text = CaseKind.SNAKE.change(
-                    enumEnum.name().toLowerCase(),
-                    CaseKind.KEBAB
-                );
-            } else {
-                text = CharSequences.quoteIfNecessary(
-                    value.toString()
-                );
-            }
-        }
-
-        return text;
+    private static CharSequence toTextValue(final Object value,
+                                            final TextStylePropertyValueHandler<?> handler) {
+        return CharSequences.quoteIfNecessary(
+            handler.makeString(
+                Cast.to(value)
+            )
+        );
     }
 
     // BoxEdge........................................................................................................

--- a/src/test/java/walkingkooka/tree/text/TextStyleNonEmptyTest.java
+++ b/src/test/java/walkingkooka/tree/text/TextStyleNonEmptyTest.java
@@ -2011,7 +2011,7 @@ public final class TextStyleNonEmptyTest extends TextStyleTestCase<TextStyleNonE
             ).set(
                 TextStylePropertyName.TEXT_ALIGN, TextAlign.LEFT
             ),
-            "color: #123456; text-align: left;"
+            "color: #123456; text-align: LEFT;"
         );
     }
 
@@ -2027,7 +2027,7 @@ public final class TextStyleNonEmptyTest extends TextStyleTestCase<TextStyleNonE
             ).set(
                 TextStylePropertyName.TEXT_ALIGN, TextAlign.LEFT
             ),
-            "background-color: #123456; color: red; text-align: left;"
+            "background-color: #123456; color: red; text-align: LEFT;"
         );
     }
 

--- a/src/test/java/walkingkooka/tree/text/TextStyleTest.java
+++ b/src/test/java/walkingkooka/tree/text/TextStyleTest.java
@@ -541,7 +541,7 @@ public final class TextStyleTest implements ClassTesting2<TextStyle>,
                     TextStylePropertyName.BORDER_BOTTOM_STYLE,
                     BorderStyle.DOTTED
                 ),
-            "border-bottom-style: dotted;"
+            "border-bottom-style: DOTTED;"
         );
     }
 
@@ -601,7 +601,7 @@ public final class TextStyleTest implements ClassTesting2<TextStyle>,
                     TextStylePropertyName.OVERFLOW_WRAP,
                     OverflowWrap.BREAK_WORD
                 ),
-            "overflow-wrap: break-word;"
+            "overflow-wrap: BREAK_WORD;"
         );
     }
 
@@ -626,6 +626,18 @@ public final class TextStyleTest implements ClassTesting2<TextStyle>,
                     "has spaces"
                 ),
             "text: \"has spaces\";"
+        );
+    }
+
+    @Test
+    public void testTextFontVariantSmallCaps() {
+        this.textAndCheck(
+            TextStyle.EMPTY
+                .set(
+                    TextStylePropertyName.FONT_VARIANT,
+                    FontVariant.SMALL_CAPS
+                ),
+            "font-variant: SMALL_CAPS;"
         );
     }
 
@@ -679,7 +691,7 @@ public final class TextStyleTest implements ClassTesting2<TextStyle>,
                     TextStylePropertyName.BORDER_TOP_WIDTH,
                     Length.pixel(123.0)
                 ),
-            "border-top-color: #123456; border-top-style: dotted; border-top-width: 123px;"
+            "border-top-color: #123456; border-top-style: DOTTED; border-top-width: 123px;"
         );
     }
 


### PR DESCRIPTION
- enum values are now upper-cased previously was lower-cased.
- enum made up of two or more tokens now keep the underscore, previously was dash which resulted in TextStyle.parse fails.