### PR TITLE
BoxEdge.xxxPropertyNamePrefix missing dash suffix FIX

### DIFF
--- a/src/main/java/walkingkooka/tree/text/BoxEdge.java
+++ b/src/main/java/walkingkooka/tree/text/BoxEdge.java
@@ -267,7 +267,7 @@ public enum BoxEdge {
 
         final String prefixConcat = "ALL".equals(name) ?
             "" :
-            this.textName;
+            this.textName.concat("-");
 
         this.borderPropertyNamePrefix = Border.PREFIX.concat(prefixConcat);
         this.marginPropertyNamePrefix = Margin.PREFIX.concat(prefixConcat);

--- a/src/test/java/walkingkooka/tree/text/BoxEdgeTest.java
+++ b/src/test/java/walkingkooka/tree/text/BoxEdgeTest.java
@@ -223,7 +223,7 @@ public final class BoxEdgeTest implements TreePrintableTesting,
     public void testBorderPropertyNamePrefixTop() {
         this.borderPropertyNamePrefixAndCheck(
             BoxEdge.TOP,
-            "border-top"
+            "border-top-"
         );
     }
 
@@ -231,7 +231,7 @@ public final class BoxEdgeTest implements TreePrintableTesting,
     public void testBorderPropertyNamePrefixRight() {
         this.borderPropertyNamePrefixAndCheck(
             BoxEdge.RIGHT,
-            "border-right"
+            "border-right-"
         );
     }
 
@@ -258,7 +258,7 @@ public final class BoxEdgeTest implements TreePrintableTesting,
     public void testMarginPropertyNamePrefixTop() {
         this.marginPropertyNamePrefixAndCheck(
             BoxEdge.TOP,
-            "margin-top"
+            "margin-top-"
         );
     }
 
@@ -266,7 +266,7 @@ public final class BoxEdgeTest implements TreePrintableTesting,
     public void testMarginPropertyNamePrefixRight() {
         this.marginPropertyNamePrefixAndCheck(
             BoxEdge.RIGHT,
-            "margin-right"
+            "margin-right-"
         );
     }
 
@@ -293,7 +293,7 @@ public final class BoxEdgeTest implements TreePrintableTesting,
     public void testPaddingPropertyNamePrefixTop() {
         this.paddingPropertyNamePrefixAndCheck(
             BoxEdge.TOP,
-            "padding-top"
+            "padding-top-"
         );
     }
 
@@ -301,7 +301,7 @@ public final class BoxEdgeTest implements TreePrintableTesting,
     public void testPaddingPropertyNamePrefixRight() {
         this.paddingPropertyNamePrefixAndCheck(
             BoxEdge.RIGHT,
-            "padding-right"
+            "padding-right-"
         );
     }
 


### PR DESCRIPTION
- only ALL had trailing dash, "border-", "margin-", "padding-"
- "border-top" etc was missing trailing dash (FIXED)